### PR TITLE
fix: restore cloud URL default + cargo fmt

### DIFF
--- a/crates/roz-cli/src/commands/interactive.rs
+++ b/crates/roz-cli/src/commands/interactive.rs
@@ -77,7 +77,7 @@ async fn onboard(config: &CliConfig, provider_config: &mut ProviderConfig) -> an
             if let Some(key) = CliConfig::load_global_api_key(&config.profile) {
                 provider_config.api_key = Some(key);
                 provider_config.provider = Provider::Cloud;
-                provider_config.api_url = "https://roz-api.fly.dev".to_string();
+                provider_config.api_url = crate::tui::provider::cloud_api_url();
             }
         }
         // Anthropic API key — password input

--- a/crates/roz-cli/src/commands/interactive.rs
+++ b/crates/roz-cli/src/commands/interactive.rs
@@ -77,7 +77,7 @@ async fn onboard(config: &CliConfig, provider_config: &mut ProviderConfig) -> an
             if let Some(key) = CliConfig::load_global_api_key(&config.profile) {
                 provider_config.api_key = Some(key);
                 provider_config.provider = Provider::Cloud;
-                provider_config.api_url = "http://localhost:8080".to_string();
+                provider_config.api_url = "https://roz-api.fly.dev".to_string();
             }
         }
         // Anthropic API key — password input

--- a/crates/roz-cli/src/config.rs
+++ b/crates/roz-cli/src/config.rs
@@ -17,7 +17,7 @@ impl CliConfig {
     /// the `"default"` profile is used.
     #[allow(clippy::unnecessary_wraps)]
     pub fn load(profile: Option<&str>) -> anyhow::Result<Self> {
-        let api_url = std::env::var("ROZ_API_URL").unwrap_or_else(|_| "http://localhost:8080".into());
+        let api_url = std::env::var("ROZ_API_URL").unwrap_or_else(|_| "https://roz-api.fly.dev".into());
         let profile_name = profile.unwrap_or("default").to_string();
         let access_token = Self::load_global_api_key(&profile_name);
 

--- a/crates/roz-cli/src/render.rs
+++ b/crates/roz-cli/src/render.rs
@@ -90,7 +90,7 @@ mod tests {
             provider: Provider::Cloud,
             model: "claude-sonnet-4-6".into(),
             api_key: Some("roz_sk_test".into()),
-            api_url: "http://localhost:8080".into(),
+            api_url: "https://roz-api.fly.dev".into(),
         };
         let lines = info_lines(&config);
         assert_eq!(lines[0], format!("roz v{}", env!("CARGO_PKG_VERSION")));

--- a/crates/roz-cli/src/tui/provider.rs
+++ b/crates/roz-cli/src/tui/provider.rs
@@ -1,5 +1,12 @@
 use crate::config::CliConfig;
 
+const DEFAULT_CLOUD_URL: &str = "https://roz-api.fly.dev";
+
+/// Resolve the Cloud API URL: `ROZ_API_URL` env var, or the default cloud endpoint.
+pub fn cloud_api_url() -> String {
+    std::env::var("ROZ_API_URL").unwrap_or_else(|_| DEFAULT_CLOUD_URL.to_string())
+}
+
 /// A streaming event from any agent backend.
 #[derive(Debug, Clone)]
 #[allow(dead_code)] // Variants wired incrementally across providers.
@@ -110,7 +117,7 @@ impl ProviderConfig {
                     provider: Provider::Cloud,
                     model: model_name.to_string(),
                     api_key: Some(key.to_string()),
-                    api_url: "https://roz-api.fly.dev".to_string(),
+                    api_url: cloud_api_url(),
                 };
             }
             // Any other key → Anthropic
@@ -154,7 +161,7 @@ impl ProviderConfig {
     fn for_provider_and_model(provider: Provider, model: &str, api_key: Option<&str>) -> Self {
         let (api_url, key) = match provider {
             Provider::Anthropic => ("https://api.anthropic.com".to_string(), api_key.map(String::from)),
-            Provider::Cloud => ("https://roz-api.fly.dev".to_string(), api_key.map(String::from)),
+            Provider::Cloud => (cloud_api_url(), api_key.map(String::from)),
             Provider::Ollama => (
                 std::env::var("OLLAMA_HOST").unwrap_or_else(|_| "http://localhost:11434".to_string()),
                 None,

--- a/crates/roz-cli/src/tui/provider.rs
+++ b/crates/roz-cli/src/tui/provider.rs
@@ -40,7 +40,7 @@ pub enum AgentEvent {
 pub enum Provider {
     /// Direct to api.anthropic.com (BYOK).
     Anthropic,
-    /// Roz Cloud gRPC (roz-api.fly.dev (override with ROZ_API_URL)).
+    /// Roz Cloud gRPC (override with `ROZ_API_URL`).
     Cloud,
     /// Local Ollama-compatible API.
     Ollama,

--- a/crates/roz-cli/src/tui/provider.rs
+++ b/crates/roz-cli/src/tui/provider.rs
@@ -33,7 +33,7 @@ pub enum AgentEvent {
 pub enum Provider {
     /// Direct to api.anthropic.com (BYOK).
     Anthropic,
-    /// Roz Cloud gRPC (localhost:8080 (or set ROZ_API_URL)).
+    /// Roz Cloud gRPC (roz-api.fly.dev (override with ROZ_API_URL)).
     Cloud,
     /// Local Ollama-compatible API.
     Ollama,
@@ -110,7 +110,7 @@ impl ProviderConfig {
                     provider: Provider::Cloud,
                     model: model_name.to_string(),
                     api_key: Some(key.to_string()),
-                    api_url: "http://localhost:8080".to_string(),
+                    api_url: "https://roz-api.fly.dev".to_string(),
                 };
             }
             // Any other key → Anthropic
@@ -154,7 +154,7 @@ impl ProviderConfig {
     fn for_provider_and_model(provider: Provider, model: &str, api_key: Option<&str>) -> Self {
         let (api_url, key) = match provider {
             Provider::Anthropic => ("https://api.anthropic.com".to_string(), api_key.map(String::from)),
-            Provider::Cloud => ("http://localhost:8080".to_string(), api_key.map(String::from)),
+            Provider::Cloud => ("https://roz-api.fly.dev".to_string(), api_key.map(String::from)),
             Provider::Ollama => (
                 std::env::var("OLLAMA_HOST").unwrap_or_else(|_| "http://localhost:11434".to_string()),
                 None,
@@ -366,7 +366,7 @@ mod tests {
             provider: Provider::Cloud,
             model: "claude-sonnet-4-6".into(),
             api_key: Some("roz_sk_test".into()),
-            api_url: "http://localhost:8080".into(),
+            api_url: "https://roz-api.fly.dev".into(),
         };
         let err = ProviderError::classify(401, "invalid key", &config);
         match err {
@@ -420,7 +420,7 @@ mod tests {
             provider: Provider::Cloud,
             model: "claude-sonnet-4-6".into(),
             api_key: Some("roz_sk_test".into()),
-            api_url: "http://localhost:8080".into(),
+            api_url: "https://roz-api.fly.dev".into(),
         };
         let result = classify_error_message("some random error", &config);
         assert_eq!(result, "some random error");

--- a/crates/roz-cli/tests/integration.rs
+++ b/crates/roz-cli/tests/integration.rs
@@ -96,7 +96,7 @@ fn detect_bare_model_with_roz_sk_routes_to_cloud() {
     );
     assert_eq!(config.model, "claude-sonnet-4-6");
     assert_eq!(config.api_key.as_deref(), Some("roz_sk_test_key_abc123"));
-    assert_eq!(config.api_url, "http://localhost:8080");
+    assert_eq!(config.api_url, "https://roz-api.fly.dev");
 }
 
 #[test]

--- a/crates/roz-copper/tests/drone_wasm_velocity.rs
+++ b/crates/roz-copper/tests/drone_wasm_velocity.rs
@@ -25,8 +25,8 @@ use arc_swap::ArcSwap;
 
 use roz_copper::channels::ControllerCommand;
 use roz_copper::io::ActuatorSink;
-use roz_copper::io_grpc::proto::{FlightCommand, FlightCommandRequest};
 use roz_copper::io_grpc::proto::control_service_client::ControlServiceClient;
+use roz_copper::io_grpc::proto::{FlightCommand, FlightCommandRequest};
 use roz_copper::io_grpc::{GrpcActuatorSink, GrpcSensorSource};
 use roz_copper::io_log::{LogActuatorSink, TeeActuatorSink};
 use roz_core::channels::ChannelManifest;
@@ -44,11 +44,7 @@ const DRONE_VZ_WAT: &str = r#"
 "#;
 
 /// Send a flight command via gRPC. Returns true on success.
-async fn send_flight_cmd(
-    channel: tonic::transport::Channel,
-    cmd: FlightCommand,
-    mode: &str,
-) -> bool {
+async fn send_flight_cmd(channel: tonic::transport::Channel, cmd: FlightCommand, mode: &str) -> bool {
     let mut client = ControlServiceClient::new(channel);
     let req = FlightCommandRequest {
         command: cmd.into(),
@@ -59,7 +55,10 @@ async fn send_flight_cmd(
     match client.send_flight_command(req).await {
         Ok(r) => {
             let inner = r.into_inner();
-            println!("FlightCommand {label}: success={}, result={}", inner.success, inner.result);
+            println!(
+                "FlightCommand {label}: success={}, result={}",
+                inner.success, inner.result
+            );
             inner.success
         }
         Err(e) => {
@@ -105,9 +104,7 @@ async fn drone_wasm_velocity_through_bridge() {
     // PX4 requires setpoints BEFORE switching to OFFBOARD mode.
     let (tx, rx) = std::sync::mpsc::sync_channel(64);
     let (_emergency_tx, emergency_rx) = std::sync::mpsc::sync_channel(1);
-    let state = Arc::new(ArcSwap::from_pointee(
-        roz_copper::channels::ControllerState::default(),
-    ));
+    let state = Arc::new(ArcSwap::from_pointee(roz_copper::channels::ControllerState::default()));
     let shutdown = Arc::new(AtomicBool::new(false));
 
     let s = Arc::clone(&state);
@@ -156,12 +153,7 @@ async fn drone_wasm_velocity_through_bridge() {
     // Wait for setpoints to stream before switching to OFFBOARD.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    let offboard_ok = send_flight_cmd(
-        grpc_channel.clone(),
-        FlightCommand::SetMode,
-        "OFFBOARD",
-    )
-    .await;
+    let offboard_ok = send_flight_cmd(grpc_channel.clone(), FlightCommand::SetMode, "OFFBOARD").await;
     if !offboard_ok {
         println!("WARNING: OFFBOARD mode switch failed — PX4 may not accept velocity setpoints");
     }
@@ -171,10 +163,7 @@ async fn drone_wasm_velocity_through_bridge() {
 
     // 6. Check results.
     let current = state.load();
-    println!(
-        "Controller: tick={}, running={}",
-        current.last_tick, current.running
-    );
+    println!("Controller: tick={}, running={}", current.last_tick, current.running);
     assert!(current.running, "controller should be running");
 
     let cmds = log_sink.commands();


### PR DESCRIPTION
- Restore roz-api.fly.dev as default cloud URL (self-hosters override with ROZ_API_URL)
- Run cargo fmt on drone_wasm_velocity.rs (CI was failing on formatting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Default Roz Cloud API endpoint updated to the production URL; CLI and interactive onboarding now use it by default while still honoring ROZ_API_URL overrides.
* **Tests**
  * Test expectations updated to reflect the new default Cloud endpoint.
* **Style**
  * Code formatting and import reorganization applied in test modules for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->