### PR TITLE
feat: export roz-server modules for cloud layer

### DIFF
--- a/crates/roz-cli/src/commands/interactive.rs
+++ b/crates/roz-cli/src/commands/interactive.rs
@@ -77,7 +77,7 @@ async fn onboard(config: &CliConfig, provider_config: &mut ProviderConfig) -> an
             if let Some(key) = CliConfig::load_global_api_key(&config.profile) {
                 provider_config.api_key = Some(key);
                 provider_config.provider = Provider::Cloud;
-                provider_config.api_url = "https://roz-api.fly.dev".to_string();
+                provider_config.api_url = crate::tui::provider::cloud_api_url();
             }
         }
         // Anthropic API key — password input

--- a/crates/roz-cli/src/commands/interactive.rs
+++ b/crates/roz-cli/src/commands/interactive.rs
@@ -77,7 +77,7 @@ async fn onboard(config: &CliConfig, provider_config: &mut ProviderConfig) -> an
             if let Some(key) = CliConfig::load_global_api_key(&config.profile) {
                 provider_config.api_key = Some(key);
                 provider_config.provider = Provider::Cloud;
-                provider_config.api_url = "http://localhost:8080".to_string();
+                provider_config.api_url = "https://roz-api.fly.dev".to_string();
             }
         }
         // Anthropic API key — password input

--- a/crates/roz-cli/src/config.rs
+++ b/crates/roz-cli/src/config.rs
@@ -17,7 +17,7 @@ impl CliConfig {
     /// the `"default"` profile is used.
     #[allow(clippy::unnecessary_wraps)]
     pub fn load(profile: Option<&str>) -> anyhow::Result<Self> {
-        let api_url = std::env::var("ROZ_API_URL").unwrap_or_else(|_| "http://localhost:8080".into());
+        let api_url = std::env::var("ROZ_API_URL").unwrap_or_else(|_| "https://roz-api.fly.dev".into());
         let profile_name = profile.unwrap_or("default").to_string();
         let access_token = Self::load_global_api_key(&profile_name);
 

--- a/crates/roz-cli/src/render.rs
+++ b/crates/roz-cli/src/render.rs
@@ -90,7 +90,7 @@ mod tests {
             provider: Provider::Cloud,
             model: "claude-sonnet-4-6".into(),
             api_key: Some("roz_sk_test".into()),
-            api_url: "http://localhost:8080".into(),
+            api_url: "https://roz-api.fly.dev".into(),
         };
         let lines = info_lines(&config);
         assert_eq!(lines[0], format!("roz v{}", env!("CARGO_PKG_VERSION")));

--- a/crates/roz-cli/src/tui/provider.rs
+++ b/crates/roz-cli/src/tui/provider.rs
@@ -1,5 +1,12 @@
 use crate::config::CliConfig;
 
+const DEFAULT_CLOUD_URL: &str = "https://roz-api.fly.dev";
+
+/// Resolve the Cloud API URL: `ROZ_API_URL` env var, or the default cloud endpoint.
+pub fn cloud_api_url() -> String {
+    std::env::var("ROZ_API_URL").unwrap_or_else(|_| DEFAULT_CLOUD_URL.to_string())
+}
+
 /// A streaming event from any agent backend.
 #[derive(Debug, Clone)]
 #[allow(dead_code)] // Variants wired incrementally across providers.
@@ -110,7 +117,7 @@ impl ProviderConfig {
                     provider: Provider::Cloud,
                     model: model_name.to_string(),
                     api_key: Some(key.to_string()),
-                    api_url: "https://roz-api.fly.dev".to_string(),
+                    api_url: cloud_api_url(),
                 };
             }
             // Any other key → Anthropic
@@ -154,7 +161,7 @@ impl ProviderConfig {
     fn for_provider_and_model(provider: Provider, model: &str, api_key: Option<&str>) -> Self {
         let (api_url, key) = match provider {
             Provider::Anthropic => ("https://api.anthropic.com".to_string(), api_key.map(String::from)),
-            Provider::Cloud => ("https://roz-api.fly.dev".to_string(), api_key.map(String::from)),
+            Provider::Cloud => (cloud_api_url(), api_key.map(String::from)),
             Provider::Ollama => (
                 std::env::var("OLLAMA_HOST").unwrap_or_else(|_| "http://localhost:11434".to_string()),
                 None,

--- a/crates/roz-cli/src/tui/provider.rs
+++ b/crates/roz-cli/src/tui/provider.rs
@@ -40,7 +40,7 @@ pub enum AgentEvent {
 pub enum Provider {
     /// Direct to api.anthropic.com (BYOK).
     Anthropic,
-    /// Roz Cloud gRPC (roz-api.fly.dev (override with ROZ_API_URL)).
+    /// Roz Cloud gRPC (override with `ROZ_API_URL`).
     Cloud,
     /// Local Ollama-compatible API.
     Ollama,

--- a/crates/roz-cli/src/tui/provider.rs
+++ b/crates/roz-cli/src/tui/provider.rs
@@ -33,7 +33,7 @@ pub enum AgentEvent {
 pub enum Provider {
     /// Direct to api.anthropic.com (BYOK).
     Anthropic,
-    /// Roz Cloud gRPC (localhost:8080 (or set ROZ_API_URL)).
+    /// Roz Cloud gRPC (roz-api.fly.dev (override with ROZ_API_URL)).
     Cloud,
     /// Local Ollama-compatible API.
     Ollama,
@@ -110,7 +110,7 @@ impl ProviderConfig {
                     provider: Provider::Cloud,
                     model: model_name.to_string(),
                     api_key: Some(key.to_string()),
-                    api_url: "http://localhost:8080".to_string(),
+                    api_url: "https://roz-api.fly.dev".to_string(),
                 };
             }
             // Any other key → Anthropic
@@ -154,7 +154,7 @@ impl ProviderConfig {
     fn for_provider_and_model(provider: Provider, model: &str, api_key: Option<&str>) -> Self {
         let (api_url, key) = match provider {
             Provider::Anthropic => ("https://api.anthropic.com".to_string(), api_key.map(String::from)),
-            Provider::Cloud => ("http://localhost:8080".to_string(), api_key.map(String::from)),
+            Provider::Cloud => ("https://roz-api.fly.dev".to_string(), api_key.map(String::from)),
             Provider::Ollama => (
                 std::env::var("OLLAMA_HOST").unwrap_or_else(|_| "http://localhost:11434".to_string()),
                 None,
@@ -366,7 +366,7 @@ mod tests {
             provider: Provider::Cloud,
             model: "claude-sonnet-4-6".into(),
             api_key: Some("roz_sk_test".into()),
-            api_url: "http://localhost:8080".into(),
+            api_url: "https://roz-api.fly.dev".into(),
         };
         let err = ProviderError::classify(401, "invalid key", &config);
         match err {
@@ -420,7 +420,7 @@ mod tests {
             provider: Provider::Cloud,
             model: "claude-sonnet-4-6".into(),
             api_key: Some("roz_sk_test".into()),
-            api_url: "http://localhost:8080".into(),
+            api_url: "https://roz-api.fly.dev".into(),
         };
         let result = classify_error_message("some random error", &config);
         assert_eq!(result, "some random error");

--- a/crates/roz-cli/tests/integration.rs
+++ b/crates/roz-cli/tests/integration.rs
@@ -96,7 +96,7 @@ fn detect_bare_model_with_roz_sk_routes_to_cloud() {
     );
     assert_eq!(config.model, "claude-sonnet-4-6");
     assert_eq!(config.api_key.as_deref(), Some("roz_sk_test_key_abc123"));
-    assert_eq!(config.api_url, "http://localhost:8080");
+    assert_eq!(config.api_url, "https://roz-api.fly.dev");
 }
 
 #[test]

--- a/crates/roz-copper/tests/drone_wasm_velocity.rs
+++ b/crates/roz-copper/tests/drone_wasm_velocity.rs
@@ -25,8 +25,8 @@ use arc_swap::ArcSwap;
 
 use roz_copper::channels::ControllerCommand;
 use roz_copper::io::ActuatorSink;
-use roz_copper::io_grpc::proto::{FlightCommand, FlightCommandRequest};
 use roz_copper::io_grpc::proto::control_service_client::ControlServiceClient;
+use roz_copper::io_grpc::proto::{FlightCommand, FlightCommandRequest};
 use roz_copper::io_grpc::{GrpcActuatorSink, GrpcSensorSource};
 use roz_copper::io_log::{LogActuatorSink, TeeActuatorSink};
 use roz_core::channels::ChannelManifest;
@@ -44,11 +44,7 @@ const DRONE_VZ_WAT: &str = r#"
 "#;
 
 /// Send a flight command via gRPC. Returns true on success.
-async fn send_flight_cmd(
-    channel: tonic::transport::Channel,
-    cmd: FlightCommand,
-    mode: &str,
-) -> bool {
+async fn send_flight_cmd(channel: tonic::transport::Channel, cmd: FlightCommand, mode: &str) -> bool {
     let mut client = ControlServiceClient::new(channel);
     let req = FlightCommandRequest {
         command: cmd.into(),
@@ -59,7 +55,10 @@ async fn send_flight_cmd(
     match client.send_flight_command(req).await {
         Ok(r) => {
             let inner = r.into_inner();
-            println!("FlightCommand {label}: success={}, result={}", inner.success, inner.result);
+            println!(
+                "FlightCommand {label}: success={}, result={}",
+                inner.success, inner.result
+            );
             inner.success
         }
         Err(e) => {
@@ -105,9 +104,7 @@ async fn drone_wasm_velocity_through_bridge() {
     // PX4 requires setpoints BEFORE switching to OFFBOARD mode.
     let (tx, rx) = std::sync::mpsc::sync_channel(64);
     let (_emergency_tx, emergency_rx) = std::sync::mpsc::sync_channel(1);
-    let state = Arc::new(ArcSwap::from_pointee(
-        roz_copper::channels::ControllerState::default(),
-    ));
+    let state = Arc::new(ArcSwap::from_pointee(roz_copper::channels::ControllerState::default()));
     let shutdown = Arc::new(AtomicBool::new(false));
 
     let s = Arc::clone(&state);
@@ -156,12 +153,7 @@ async fn drone_wasm_velocity_through_bridge() {
     // Wait for setpoints to stream before switching to OFFBOARD.
     tokio::time::sleep(Duration::from_millis(500)).await;
 
-    let offboard_ok = send_flight_cmd(
-        grpc_channel.clone(),
-        FlightCommand::SetMode,
-        "OFFBOARD",
-    )
-    .await;
+    let offboard_ok = send_flight_cmd(grpc_channel.clone(), FlightCommand::SetMode, "OFFBOARD").await;
     if !offboard_ok {
         println!("WARNING: OFFBOARD mode switch failed — PX4 may not accept velocity setpoints");
     }
@@ -171,10 +163,7 @@ async fn drone_wasm_velocity_through_bridge() {
 
     // 6. Check results.
     let current = state.load();
-    println!(
-        "Controller: tick={}, running={}",
-        current.last_tick, current.running
-    );
+    println!("Controller: tick={}, running={}", current.last_tick, current.running);
     assert!(current.running, "controller should be running");
 
     let cmds = log_sink.commands();

--- a/crates/roz-server/src/lib.rs
+++ b/crates/roz-server/src/lib.rs
@@ -1,2 +1,122 @@
+pub mod auth;
+pub mod config;
+pub mod error;
 pub mod grpc;
+pub mod middleware;
+pub mod nats_handlers;
+pub mod response;
 pub mod restate;
+pub mod routes;
+pub mod state;
+pub mod triggers;
+pub mod ws;
+
+use axum::Router;
+use axum::routing::{delete, get, patch, post};
+use tower_http::trace::TraceLayer;
+
+use state::AppState;
+
+/// Build the full REST + WebSocket router with all routes and middleware.
+///
+/// Cloud wrappers can call this and layer their own auth middleware on top.
+pub fn build_router(state: AppState) -> Router {
+    Router::new()
+        .route("/v1/health", get(routes::health::health))
+        .route("/v1/ready", get(routes::health::ready))
+        .route("/healthz", get(routes::health::healthz))
+        .route("/readyz", get(routes::health::readyz))
+        .route("/startupz", get(routes::health::startupz))
+        .route("/v1/auth/keys", post(routes::auth_keys::create_key))
+        .route("/v1/auth/keys", get(routes::auth_keys::list_keys))
+        .route("/v1/auth/keys/{id}", delete(routes::auth_keys::revoke_key))
+        .route("/v1/auth/keys/{id}/rotate", post(routes::auth_keys::rotate_key))
+        .route(
+            "/v1/environments",
+            get(routes::environments::list).post(routes::environments::create),
+        )
+        .route(
+            "/v1/environments/{id}",
+            get(routes::environments::get)
+                .put(routes::environments::update)
+                .delete(routes::environments::delete),
+        )
+        // Host CRUD + status
+        .route("/v1/hosts", get(routes::hosts::list).post(routes::hosts::create))
+        .route(
+            "/v1/hosts/{id}",
+            get(routes::hosts::get)
+                .put(routes::hosts::update)
+                .delete(routes::hosts::delete),
+        )
+        .route("/v1/hosts/{id}/status", patch(routes::hosts::update_status))
+        // Task CRUD
+        .route("/v1/tasks", get(routes::tasks::list).post(routes::tasks::create))
+        .route("/v1/tasks/{id}", get(routes::tasks::get).delete(routes::tasks::delete))
+        .route("/v1/tasks/{id}/approve", post(routes::tasks::approve))
+        // Trigger CRUD + toggle
+        .route(
+            "/v1/triggers",
+            get(routes::triggers::list).post(routes::triggers::create),
+        )
+        .route(
+            "/v1/triggers/{id}",
+            get(routes::triggers::get)
+                .put(routes::triggers::update)
+                .delete(routes::triggers::delete),
+        )
+        .route("/v1/triggers/{id}/toggle", post(routes::triggers::toggle))
+        // Stream CRUD
+        .route("/v1/streams", get(routes::streams::list).post(routes::streams::create))
+        .route(
+            "/v1/streams/{id}",
+            get(routes::streams::get)
+                .put(routes::streams::update)
+                .delete(routes::streams::delete),
+        )
+        // Command routes + state transition
+        .route(
+            "/v1/commands",
+            get(routes::commands::list).post(routes::commands::create),
+        )
+        .route(
+            "/v1/commands/{id}",
+            get(routes::commands::get).delete(routes::commands::delete),
+        )
+        .route("/v1/commands/{id}/transition", post(routes::commands::transition))
+        // Lease acquire/release
+        .route("/v1/leases", get(routes::leases::list).post(routes::leases::create))
+        .route("/v1/leases/{id}", get(routes::leases::get))
+        .route("/v1/leases/{id}/release", post(routes::leases::release))
+        // Safety policy CRUD
+        .route(
+            "/v1/safety-policies",
+            get(routes::safety_policies::list).post(routes::safety_policies::create),
+        )
+        .route(
+            "/v1/safety-policies/{id}",
+            get(routes::safety_policies::get)
+                .put(routes::safety_policies::update)
+                .delete(routes::safety_policies::delete),
+        )
+        // Metrics
+        .route("/v1/metrics/tasks", get(routes::metrics::task_metrics))
+        .route("/v1/metrics/hosts", get(routes::metrics::host_metrics))
+        // WebSocket
+        .route("/v1/ws", get(ws::handler::ws_upgrade))
+        .route("/v1/auth/device/code", post(routes::device_auth::request_code))
+        .route("/v1/auth/device/token", post(routes::device_auth::poll_token))
+        .route("/v1/auth/device/complete", post(routes::device_auth::complete_auth))
+        // Webhook routes can be added here for custom integrations.
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            middleware::tenant::auth_middleware,
+        ))
+        .layer(axum::middleware::from_fn(middleware::request_id::request_id_middleware))
+        .with_state(state)
+        .layer(
+            TraceLayer::new_for_http().make_span_with(|_req: &axum::http::Request<axum::body::Body>| {
+                tracing::info_span!("http_request", request_id = tracing::field::Empty)
+            }),
+        )
+}

--- a/crates/roz-server/src/main.rs
+++ b/crates/roz-server/src/main.rs
@@ -1,24 +1,12 @@
 use axum::Router;
-use axum::routing::{delete, get, patch, post};
 use std::convert::Infallible;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use tower::Service;
-use tower_http::trace::TraceLayer;
 
-mod auth;
-mod config;
-mod error;
-mod middleware;
-mod nats_handlers;
-mod response;
-mod routes;
-mod state;
-#[allow(dead_code)]
-mod triggers;
-mod ws;
-
-use state::AppState;
+use roz_server::middleware;
+use roz_server::nats_handlers;
+use roz_server::state::{AppState, ModelConfig};
 
 /// Routes requests by content-type: `application/grpc` → tonic, everything else → axum REST.
 #[derive(Clone)]
@@ -53,104 +41,7 @@ impl Service<axum::extract::Request> for MultiplexService {
 }
 
 fn app(state: AppState) -> Router {
-    Router::new()
-        .route("/v1/health", get(routes::health::health))
-        .route("/v1/ready", get(routes::health::ready))
-        .route("/healthz", get(routes::health::healthz))
-        .route("/readyz", get(routes::health::readyz))
-        .route("/startupz", get(routes::health::startupz))
-        .route("/v1/auth/keys", post(routes::auth_keys::create_key))
-        .route("/v1/auth/keys", get(routes::auth_keys::list_keys))
-        .route("/v1/auth/keys/{id}", delete(routes::auth_keys::revoke_key))
-        .route("/v1/auth/keys/{id}/rotate", post(routes::auth_keys::rotate_key))
-        .route(
-            "/v1/environments",
-            get(routes::environments::list).post(routes::environments::create),
-        )
-        .route(
-            "/v1/environments/{id}",
-            get(routes::environments::get)
-                .put(routes::environments::update)
-                .delete(routes::environments::delete),
-        )
-        // Host CRUD + status
-        .route("/v1/hosts", get(routes::hosts::list).post(routes::hosts::create))
-        .route(
-            "/v1/hosts/{id}",
-            get(routes::hosts::get)
-                .put(routes::hosts::update)
-                .delete(routes::hosts::delete),
-        )
-        .route("/v1/hosts/{id}/status", patch(routes::hosts::update_status))
-        // Task CRUD
-        .route("/v1/tasks", get(routes::tasks::list).post(routes::tasks::create))
-        .route("/v1/tasks/{id}", get(routes::tasks::get).delete(routes::tasks::delete))
-        .route("/v1/tasks/{id}/approve", post(routes::tasks::approve))
-        // Trigger CRUD + toggle
-        .route(
-            "/v1/triggers",
-            get(routes::triggers::list).post(routes::triggers::create),
-        )
-        .route(
-            "/v1/triggers/{id}",
-            get(routes::triggers::get)
-                .put(routes::triggers::update)
-                .delete(routes::triggers::delete),
-        )
-        .route("/v1/triggers/{id}/toggle", post(routes::triggers::toggle))
-        // Stream CRUD
-        .route("/v1/streams", get(routes::streams::list).post(routes::streams::create))
-        .route(
-            "/v1/streams/{id}",
-            get(routes::streams::get)
-                .put(routes::streams::update)
-                .delete(routes::streams::delete),
-        )
-        // Command routes + state transition
-        .route(
-            "/v1/commands",
-            get(routes::commands::list).post(routes::commands::create),
-        )
-        .route(
-            "/v1/commands/{id}",
-            get(routes::commands::get).delete(routes::commands::delete),
-        )
-        .route("/v1/commands/{id}/transition", post(routes::commands::transition))
-        // Lease acquire/release
-        .route("/v1/leases", get(routes::leases::list).post(routes::leases::create))
-        .route("/v1/leases/{id}", get(routes::leases::get))
-        .route("/v1/leases/{id}/release", post(routes::leases::release))
-        // Safety policy CRUD
-        .route(
-            "/v1/safety-policies",
-            get(routes::safety_policies::list).post(routes::safety_policies::create),
-        )
-        .route(
-            "/v1/safety-policies/{id}",
-            get(routes::safety_policies::get)
-                .put(routes::safety_policies::update)
-                .delete(routes::safety_policies::delete),
-        )
-        // Metrics
-        .route("/v1/metrics/tasks", get(routes::metrics::task_metrics))
-        .route("/v1/metrics/hosts", get(routes::metrics::host_metrics))
-        // WebSocket
-        .route("/v1/ws", get(ws::handler::ws_upgrade))
-        .route("/v1/auth/device/code", post(routes::device_auth::request_code))
-        .route("/v1/auth/device/token", post(routes::device_auth::poll_token))
-        .route("/v1/auth/device/complete", post(routes::device_auth::complete_auth))
-        // Webhook routes can be added here for custom integrations.
-        .layer(axum::middleware::from_fn_with_state(
-            state.clone(),
-            middleware::tenant::auth_middleware,
-        ))
-        .layer(axum::middleware::from_fn(middleware::request_id::request_id_middleware))
-        .with_state(state)
-        .layer(
-            TraceLayer::new_for_http().make_span_with(|_req: &axum::http::Request<axum::body::Body>| {
-                tracing::info_span!("http_request", request_id = tracing::field::Empty)
-            }),
-        )
+    roz_server::build_router(state)
 }
 
 // ---------------------------------------------------------------------------
@@ -322,7 +213,7 @@ async fn main() {
         None
     };
 
-    let model_config = state::ModelConfig {
+    let model_config = ModelConfig {
         gateway_url: std::env::var("ROZ_GATEWAY_URL").unwrap_or_else(|_| "https://gateway-us.pydantic.dev".into()),
         api_key: std::env::var("ROZ_GATEWAY_API_KEY").unwrap_or_default(),
         default_model: std::env::var("ROZ_DEFAULT_MODEL").unwrap_or_else(|_| "claude-sonnet-4-6".into()),
@@ -402,7 +293,7 @@ mod tests {
             http_client: reqwest::Client::new(),
             operator_seed,
             nats_client: None,
-            model_config: state::ModelConfig {
+            model_config: ModelConfig {
                 gateway_url: "http://test-gateway".to_string(),
                 api_key: "test-key".to_string(),
                 default_model: "test-model".to_string(),

--- a/crates/roz-server/src/nats_handlers.rs
+++ b/crates/roz-server/src/nats_handlers.rs
@@ -94,7 +94,7 @@ async fn spawn_task_handler(nats: NatsClient, pool: PgPool, restate_ingress_url:
         };
 
         // Fire-and-forget Restate workflow start (mirrors routes/tasks.rs pattern).
-        let workflow_input = roz_server::restate::task_workflow::TaskInput {
+        let workflow_input = crate::restate::task_workflow::TaskInput {
             task_id: task.id,
             environment_id: task.environment_id,
             prompt: task.prompt.clone(),

--- a/crates/roz-server/src/routes/tasks.rs
+++ b/crates/roz-server/src/routes/tasks.rs
@@ -64,7 +64,7 @@ pub async fn create(
 
     // Start Restate workflow (fire-and-forget -- workflow manages its own lifecycle).
     // The workflow must be registered before NATS publish so the worker can signal back.
-    let workflow_input = roz_server::restate::task_workflow::TaskInput {
+    let workflow_input = crate::restate::task_workflow::TaskInput {
         task_id: task.id,
         environment_id: task.environment_id,
         prompt: task.prompt.clone(),
@@ -119,7 +119,7 @@ pub async fn approve(
     State(state): State<AppState>,
     Extension(auth): Extension<AuthIdentity>,
     Path(task_id): Path<Uuid>,
-    Json(body): Json<roz_server::restate::task_workflow::ToolApproval>,
+    Json(body): Json<crate::restate::task_workflow::ToolApproval>,
 ) -> Result<StatusCode, AppError> {
     // Verify tenant ownership
     let tenant_id = *auth.tenant_id().as_uuid();


### PR DESCRIPTION
## Summary

- Makes roz-server internal modules (auth, config, error, grpc, middleware, nats_handlers, response, restate, routes, state, triggers, ws) public in lib.rs
- Extracts build_router(AppState) -> Router from main.rs into lib.rs so cloud wrappers can compose on top
- Fixes roz_server:: -> crate:: path references in routes/tasks.rs and nats_handlers.rs

This enables roz-cloud-auth to import roz-server as a library and layer Clerk JWT auth + webhook routes on top of the base router.

## Test plan

- [x] cargo fmt --check passes
- [x] cargo clippy --workspace -- -D warnings passes
- [x] cargo build --workspace passes
- [x] cargo test --workspace --exclude roz-db passes
- [ ] Verify roz-cloud-auth can import and use roz_server::build_router

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  - Updated Cloud API endpoint to use production URL (https://roz-api.fly.dev) by default instead of localhost; configure via ROZ_API_URL environment variable

* **Chores**
  - Refactored server router initialization and internal module organization for improved code structure; updated internal type references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->