### PR TITLE
feat: pluggable RestAuth trait for cloud JWT support

### DIFF
--- a/crates/roz-server/src/auth/mod.rs
+++ b/crates/roz-server/src/auth/mod.rs
@@ -3,8 +3,8 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use roz_core::auth::{ApiKeyScope, AuthIdentity, TenantId};
 use serde_json::json;
-
-use crate::state::AppState;
+use sqlx::PgPool;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct AuthError(pub String);
@@ -15,43 +15,70 @@ impl IntoResponse for AuthError {
     }
 }
 
-/// Extract auth from Authorization header.
+/// Pluggable REST auth — same pattern as `GrpcAuth` in `grpc::agent`.
 ///
-/// Supports `Bearer roz_sk_...` API key auth (looked up in Postgres).
-pub async fn extract_auth(state: &AppState, auth_header: Option<&str>) -> Result<AuthIdentity, AuthError> {
+/// OSS uses `ApiKeyAuth` (`roz_sk_` only). Cloud injects its own impl
+/// that also accepts Clerk JWTs.
+#[tonic::async_trait]
+pub trait RestAuth: Send + Sync + 'static {
+    async fn authenticate(&self, pool: &PgPool, auth_header: Option<&str>) -> Result<AuthIdentity, AuthError>;
+}
+
+/// Default auth: API key only (`Bearer roz_sk_...`).
+pub struct ApiKeyAuth;
+
+#[tonic::async_trait]
+impl RestAuth for ApiKeyAuth {
+    async fn authenticate(&self, pool: &PgPool, auth_header: Option<&str>) -> Result<AuthIdentity, AuthError> {
+        extract_api_key_auth(pool, auth_header).await
+    }
+}
+
+/// Extract API key auth from an Authorization header.
+///
+/// Reusable by cloud impls that want API key as a fallback path.
+pub async fn extract_api_key_auth(pool: &PgPool, auth_header: Option<&str>) -> Result<AuthIdentity, AuthError> {
     let header = auth_header.ok_or_else(|| AuthError("missing authorization header".into()))?;
 
     let token = header
         .strip_prefix("Bearer ")
         .ok_or_else(|| AuthError("invalid authorization format".into()))?;
 
-    if token.starts_with("roz_sk_") {
-        // API key auth
-        let api_key = roz_db::api_keys::verify_api_key(&state.pool, token)
-            .await
-            .map_err(|e| AuthError(format!("database error: {e}")))?
-            .ok_or_else(|| AuthError("invalid or revoked API key".into()))?;
-
-        let scopes = api_key
-            .scopes
-            .iter()
-            .filter_map(|s| match serde_json::from_value::<ApiKeyScope>(json!(s)) {
-                Ok(scope) => Some(scope),
-                Err(e) => {
-                    tracing::warn!(scope = ?s, error = %e, "ignoring unparseable API key scope");
-                    None
-                }
-            })
-            .collect::<Vec<ApiKeyScope>>();
-
-        Ok(AuthIdentity::ApiKey {
-            key_id: api_key.id,
-            tenant_id: TenantId::new(api_key.tenant_id),
-            scopes,
-        })
-    } else {
-        Err(AuthError(
+    if !token.starts_with("roz_sk_") {
+        return Err(AuthError(
             "only API key auth is supported — use Bearer roz_sk_...".into(),
-        ))
+        ));
     }
+
+    let api_key = roz_db::api_keys::verify_api_key(pool, token)
+        .await
+        .map_err(|e| AuthError(format!("database error: {e}")))?
+        .ok_or_else(|| AuthError("invalid or revoked API key".into()))?;
+
+    let scopes = api_key
+        .scopes
+        .iter()
+        .filter_map(|s| match serde_json::from_value::<ApiKeyScope>(json!(s)) {
+            Ok(scope) => Some(scope),
+            Err(e) => {
+                tracing::warn!(scope = ?s, error = %e, "ignoring unparseable API key scope");
+                None
+            }
+        })
+        .collect::<Vec<ApiKeyScope>>();
+
+    Ok(AuthIdentity::ApiKey {
+        key_id: api_key.id,
+        tenant_id: TenantId::new(api_key.tenant_id),
+        scopes,
+    })
+}
+
+/// Convenience wrapper used by the OSS binary's auth middleware.
+pub async fn extract_auth(
+    auth: &Arc<dyn RestAuth>,
+    pool: &PgPool,
+    auth_header: Option<&str>,
+) -> Result<AuthIdentity, AuthError> {
+    auth.authenticate(pool, auth_header).await
 }

--- a/crates/roz-server/src/main.rs
+++ b/crates/roz-server/src/main.rs
@@ -242,6 +242,7 @@ async fn main() {
         operator_seed,
         nats_client,
         model_config,
+        auth: Arc::new(roz_server::auth::ApiKeyAuth),
     };
 
     // Spawn internal NATS request-reply handlers (e.g. spawn_worker tool bypass).
@@ -301,6 +302,7 @@ mod tests {
                 anthropic_provider: "anthropic".to_string(),
                 direct_api_key: None,
             },
+            auth: Arc::new(roz_server::auth::ApiKeyAuth),
         }
     }
 

--- a/crates/roz-server/src/middleware/tenant.rs
+++ b/crates/roz-server/src/middleware/tenant.rs
@@ -49,7 +49,7 @@ pub async fn auth_middleware(
         .and_then(|v| v.to_str().ok())
         .map(String::from);
 
-    match crate::auth::extract_auth(&state, auth_header.as_deref()).await {
+    match crate::auth::extract_auth(&state.auth, &state.pool, auth_header.as_deref()).await {
         Ok(identity) => {
             req.extensions_mut().insert(identity);
             next.run(req).await

--- a/crates/roz-server/src/routes/auth_keys.rs
+++ b/crates/roz-server/src/routes/auth_keys.rs
@@ -20,7 +20,7 @@ pub async fn create_key(
     Json(body): Json<CreateKeyRequest>,
 ) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Value>)> {
     let auth_header = headers.get("authorization").and_then(|v| v.to_str().ok());
-    let auth = crate::auth::extract_auth(&state, auth_header)
+    let auth = crate::auth::extract_auth(&state.auth, &state.pool, auth_header)
         .await
         .map_err(|e| (StatusCode::UNAUTHORIZED, Json(json!({ "error": e.0 }))))?;
 
@@ -60,7 +60,7 @@ pub async fn list_keys(
     headers: HeaderMap,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
     let auth_header = headers.get("authorization").and_then(|v| v.to_str().ok());
-    let auth = crate::auth::extract_auth(&state, auth_header)
+    let auth = crate::auth::extract_auth(&state.auth, &state.pool, auth_header)
         .await
         .map_err(|e| (StatusCode::UNAUTHORIZED, Json(json!({ "error": e.0 }))))?;
 
@@ -98,7 +98,7 @@ pub async fn revoke_key(
     Path(key_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<Value>)> {
     let auth_header = headers.get("authorization").and_then(|v| v.to_str().ok());
-    let auth = crate::auth::extract_auth(&state, auth_header)
+    let auth = crate::auth::extract_auth(&state.auth, &state.pool, auth_header)
         .await
         .map_err(|e| (StatusCode::UNAUTHORIZED, Json(json!({ "error": e.0 }))))?;
 
@@ -127,7 +127,7 @@ pub async fn rotate_key(
     Path(key_id): Path<Uuid>,
 ) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Value>)> {
     let auth_header = headers.get("authorization").and_then(|v| v.to_str().ok());
-    let auth = crate::auth::extract_auth(&state, auth_header)
+    let auth = crate::auth::extract_auth(&state.auth, &state.pool, auth_header)
         .await
         .map_err(|e| (StatusCode::UNAUTHORIZED, Json(json!({ "error": e.0 }))))?;
 

--- a/crates/roz-server/src/routes/device_auth.rs
+++ b/crates/roz-server/src/routes/device_auth.rs
@@ -158,7 +158,7 @@ pub async fn complete_auth(
     Form(body): Form<CompleteRequest>,
 ) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Value>)> {
     let auth_header = headers.get("authorization").and_then(|v| v.to_str().ok());
-    let auth = crate::auth::extract_auth(&state, auth_header)
+    let auth = crate::auth::extract_auth(&state.auth, &state.pool, auth_header)
         .await
         .map_err(|e| (StatusCode::UNAUTHORIZED, Json(json!({"error": e.0}))))?;
 

--- a/crates/roz-server/src/state.rs
+++ b/crates/roz-server/src/state.rs
@@ -1,3 +1,4 @@
+use crate::auth::RestAuth;
 use crate::middleware::rate_limit::KeyedRateLimiter;
 use sqlx::PgPool;
 use std::sync::Arc;
@@ -39,4 +40,6 @@ pub struct AppState {
     pub nats_client: Option<async_nats::Client>,
     /// Model provider config for creating LLM model instances in gRPC sessions.
     pub model_config: ModelConfig,
+    /// Pluggable REST auth provider. OSS uses `ApiKeyAuth`, cloud injects Clerk JWT support.
+    pub auth: Arc<dyn RestAuth>,
 }


### PR DESCRIPTION
## Summary
- Adds `RestAuth` trait in `auth/mod.rs` — same pattern as `GrpcAuth` for gRPC sessions
- `AppState` now carries `Arc<dyn RestAuth>` so binaries can inject their own auth
- OSS uses `ApiKeyAuth` (roz_sk_ only), cloud injects Clerk JWT + API key support
- Extracts `extract_api_key_auth()` as a reusable helper for cloud fallback path

## Why
`build_router()` bakes in the OSS auth middleware which only accepts `roz_sk_` API keys. When Studio (bedrockdynamics.studio) hits the roz API with a Clerk JWT, the OSS middleware rejects it with "only API key auth is supported". The gRPC path already handles this correctly via the `GrpcAuth` trait — this applies the same pattern to REST.

## Test plan
- [ ] `cargo build -p roz-server`
- [ ] `cargo clippy -p roz-server -- -D warnings`
- [ ] CI passes
- [ ] roz-cloud-auth implements `CloudRestAuth` and deploys with Clerk JWT support

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal authentication system refactored to improve modularity and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->