### PR TITLE
fix: credentials determine provider, not project config

### DIFF
--- a/crates/roz-cli/src/commands/interactive.rs
+++ b/crates/roz-cli/src/commands/interactive.rs
@@ -140,20 +140,13 @@ fn read_roz_toml() -> RozTomlConfig {
         };
     }
 
-    // Legacy fallback: combine [model] provider + model/name
-    let provider = model_section
-        .and_then(|m| m.get("provider"))
-        .and_then(toml::Value::as_str);
+    // Legacy fallback: [model] provider field is IGNORED (provider comes from credentials).
+    // Only read the model/name field.
     let model = model_section
         .and_then(|m| m.get("model").or_else(|| m.get("name")))
         .and_then(toml::Value::as_str);
 
-    let model_ref = match (provider, model) {
-        (Some(p), Some(m)) => Some(format!("{p}/{m}")),
-        (Some(p), None) => Some(p.to_string()),
-        (None, Some(m)) => Some(m.to_string()),
-        (None, None) => None,
-    };
-
-    RozTomlConfig { model_ref }
+    RozTomlConfig {
+        model_ref: model.map(String::from),
+    }
 }

--- a/crates/roz-cli/src/commands/non_interactive.rs
+++ b/crates/roz-cli/src/commands/non_interactive.rs
@@ -1,5 +1,5 @@
 use crate::config::CliConfig;
-use crate::tui::provider::{Provider, ProviderConfig};
+use crate::tui::provider::{AgentEvent, Provider, ProviderConfig};
 
 /// Run a single prompt without the TUI and output JSON to stdout.
 ///
@@ -13,9 +13,77 @@ pub async fn execute(config: &CliConfig, model_flag: Option<&str>, task: &str) -
         anyhow::bail!("No credentials configured. Run `roz auth login` or set ANTHROPIC_API_KEY.");
     }
 
-    // For Cloud provider, fall back to BYOK-style execution for now.
-    // TODO: implement cloud non-interactive via gRPC StreamSession.
-    execute_byok(&provider_config, task).await
+    if provider_config.provider == Provider::Cloud {
+        execute_cloud(&provider_config, task).await
+    } else {
+        execute_byok(&provider_config, task).await
+    }
+}
+
+async fn execute_cloud(config: &ProviderConfig, task: &str) -> anyhow::Result<()> {
+    let (event_tx, event_rx) = async_channel::unbounded();
+    let (text_tx, text_rx) = async_channel::unbounded::<String>();
+
+    // Send the task as a single message
+    text_tx.send(task.to_string()).await?;
+    text_tx.close();
+
+    // Spawn gRPC session in background
+    let config_clone = config.clone();
+    let session =
+        tokio::spawn(
+            async move { crate::tui::providers::cloud::stream_session(&config_clone, text_rx, event_tx).await },
+        );
+
+    // Collect streaming response
+    let mut response = String::new();
+    let mut input_tokens = 0u64;
+    let mut output_tokens = 0u64;
+    let mut cycles = 0u32;
+
+    while let Ok(event) = event_rx.recv().await {
+        match event {
+            AgentEvent::TextDelta(text) => {
+                response.push_str(&text);
+            }
+            AgentEvent::TurnComplete {
+                input_tokens: inp,
+                output_tokens: out,
+                ..
+            } => {
+                input_tokens += u64::from(inp);
+                output_tokens += u64::from(out);
+                cycles += 1;
+            }
+            AgentEvent::Error(e) => {
+                let json = serde_json::json!({
+                    "status": "error",
+                    "error": e,
+                });
+                println!("{}", serde_json::to_string_pretty(&json)?);
+                std::process::exit(1);
+            }
+            _ => {}
+        }
+    }
+
+    // Wait for session to finish
+    if let Err(e) = session.await? {
+        anyhow::bail!("Cloud session error: {e}");
+    }
+
+    let json = serde_json::json!({
+        "status": "success",
+        "response": response,
+        "usage": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        },
+        "cycles": cycles,
+    });
+    println!("{}", serde_json::to_string_pretty(&json)?);
+
+    Ok(())
 }
 
 async fn execute_byok(config: &ProviderConfig, task: &str) -> anyhow::Result<()> {

--- a/crates/roz-cli/src/tui/mod.rs
+++ b/crates/roz-cli/src/tui/mod.rs
@@ -9,7 +9,7 @@ pub mod markdown;
 mod pricing;
 mod proto;
 pub mod provider;
-mod providers;
+pub(crate) mod providers;
 #[allow(dead_code)] // State variants/modes used as backends mature.
 pub mod session;
 #[allow(dead_code)] // Team event formatter wired when gRPC streaming lands.

--- a/crates/roz-cli/src/tui/provider.rs
+++ b/crates/roz-cli/src/tui/provider.rs
@@ -103,14 +103,15 @@ impl ProviderConfig {
         // 2. Parse ref into (provider_prefix, model_name)
         let (provider_prefix, model_name) = parse_model_ref(model_ref);
 
-        // 3. If provider is explicit in the ref, use it directly
-        if let Some(prefix) = provider_prefix
+        // 3. If EXPLICIT CLI FLAG has a provider prefix, use it (user intent)
+        if explicit_model.is_some()
+            && let Some(prefix) = provider_prefix
             && let Ok(provider) = prefix.parse::<Provider>()
         {
             return Self::for_provider_and_model(provider, model_name, api_key);
         }
 
-        // 4. Auto-detect from credential prefix
+        // 4. Auto-detect provider from credential prefix (credentials determine provider)
         if let Some(key) = api_key {
             if key.starts_with("roz_sk_") {
                 return Self {
@@ -149,7 +150,14 @@ impl ProviderConfig {
             };
         }
 
-        // 7. No credentials — disconnected fallback
+        // 7. If roz_toml had a provider prefix (no credentials), use it as hint
+        if let Some(prefix) = provider_prefix
+            && let Ok(provider) = prefix.parse::<Provider>()
+        {
+            return Self::for_provider_and_model(provider, model_name, api_key);
+        }
+
+        // 8. No credentials — disconnected fallback
         Self {
             provider: Provider::Anthropic,
             model: model_name.to_string(),
@@ -431,5 +439,19 @@ mod tests {
         };
         let result = classify_error_message("some random error", &config);
         assert_eq!(result, "some random error");
+    }
+
+    #[test]
+    fn detect_roz_toml_provider_prefix_ignored_when_roz_sk() {
+        let config = ProviderConfig::detect(None, Some("roz_sk_test_key"), Some("anthropic/claude-sonnet-4-6"));
+        assert_eq!(config.provider, Provider::Cloud);
+        assert_eq!(config.model, "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn detect_explicit_model_flag_still_overrides() {
+        let config = ProviderConfig::detect(Some("anthropic/claude-opus-4-6"), Some("roz_sk_test_key"), None);
+        assert_eq!(config.provider, Provider::Anthropic);
+        assert_eq!(config.model, "claude-opus-4-6");
     }
 }


### PR DESCRIPTION
## Summary
- `roz.toml` `[model] provider` field no longer overrides user credentials
- Credentials determine provider: `roz_sk_` -> Cloud, `sk-ant-` -> Anthropic
- `--model` flag still allows explicit provider override (user intent)
- Non-interactive mode now supports Cloud via gRPC (was BYOK-only)

## Why
Industry standard (Claude Code, AWS CLI, gcloud, NemoClaw): project config controls *what* (model), credentials control *where* (provider). A `roz.toml` with `provider = "anthropic"` was overriding `roz auth login` Cloud credentials.

## Changes
1. `interactive.rs` — `read_roz_toml()` ignores legacy `[model] provider` field
2. `provider.rs` — `detect()` only honors provider prefix from `--model` flag, not `roz_toml`; credentials always determine provider
3. `non_interactive.rs` — Cloud provider routes through `stream_session()` gRPC instead of BYOK Anthropic fallback

## Test plan
- [x] `cargo test -p roz-cli` (124 tests pass)
- [x] `cargo clippy -p roz-cli -- -D warnings` (clean)
- [ ] `roz doctor` shows Cloud credentials
- [ ] `roz` interactive shows Provider::Cloud (not Anthropic)
- [ ] `roz --non-interactive --task "hello"` works with Cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dedicated cloud provider execution path in non-interactive mode with structured output including response text, token usage metrics, and cycle counts.

* **Improvements**
  * Enhanced provider detection to better prioritize explicit CLI arguments, cloud credentials, and configuration file settings in the correct order.
  * Improved model reference resolution to more accurately handle provider and model configuration sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->