### PR TITLE
Safety hardening, robot.toml config, position-control support

### DIFF
--- a/crates/roz-agent/src/tools/execute_code.rs
+++ b/crates/roz-agent/src/tools/execute_code.rs
@@ -82,7 +82,7 @@ impl TypedToolExecutor for ExecuteCodeTool {
     async fn execute(
         &self,
         input: Self::Input,
-        _ctx: &ToolContext,
+        ctx: &ToolContext,
     ) -> Result<ToolResult, Box<dyn std::error::Error + Send + Sync>> {
         const MAX_CODE_SIZE: usize = 100_000; // 100 KB
         if input.code.len() > MAX_CODE_SIZE {
@@ -100,9 +100,16 @@ impl TypedToolExecutor for ExecuteCodeTool {
             return Ok(ToolResult::error(serde_json::to_string(&output)?));
         }
 
-        // Try WAT/WASM first — use production safety limits for verification.
-        // Use a UR5-like manifest so that set_velocity has proper limits.
-        let manifest = roz_core::channels::ChannelManifest::ur5();
+        // Read manifest from context — no UR5 fallback.
+        let manifest = ctx
+            .extensions
+            .get::<roz_core::channels::ChannelManifest>()
+            .cloned()
+            .ok_or_else(|| {
+                Box::<dyn std::error::Error + Send + Sync>::from(
+                    "no ChannelManifest in ToolContext — configure the robot type before executing code",
+                )
+            })?;
         let host_ctx = roz_copper::wit_host::HostContext::with_manifest(manifest);
         let wasm_result = roz_copper::wasm::CuWasmTask::from_source_with_host(input.code.as_bytes(), host_ctx);
         let mut task = match wasm_result {
@@ -185,11 +192,13 @@ mod tests {
     use super::*;
 
     fn test_ctx() -> ToolContext {
+        let mut ext = crate::dispatch::Extensions::new();
+        ext.insert(roz_core::channels::ChannelManifest::ur5());
         ToolContext {
             task_id: "test-task".to_string(),
             tenant_id: "test-tenant".to_string(),
             call_id: String::new(),
-            extensions: crate::dispatch::Extensions::default(),
+            extensions: ext,
         }
     }
 

--- a/crates/roz-agent/src/tools/execute_code.rs
+++ b/crates/roz-agent/src/tools/execute_code.rs
@@ -193,7 +193,10 @@ mod tests {
 
     fn test_ctx() -> ToolContext {
         let mut ext = crate::dispatch::Extensions::new();
-        ext.insert(roz_core::channels::ChannelManifest::ur5());
+        ext.insert(roz_core::channels::ChannelManifest::generic_velocity(
+            6,
+            std::f64::consts::PI,
+        ));
         ToolContext {
             task_id: "test-task".to_string(),
             tenant_id: "test-tenant".to_string(),

--- a/crates/roz-agent/tests/e2e_code_execution.rs
+++ b/crates/roz-agent/tests/e2e_code_execution.rs
@@ -11,13 +11,20 @@
 //! Run: cargo test -p roz-agent --test e2e_code_execution
 
 use roz_agent::agent_loop::{AgentInput, AgentLoop, AgentLoopMode};
-use roz_agent::dispatch::ToolDispatcher;
+use roz_agent::dispatch::{Extensions, ToolDispatcher};
 use roz_agent::model::types::*;
 use roz_agent::safety::SafetyStack;
 use roz_agent::spatial_provider::MockSpatialContextProvider;
 use roz_agent::tools::execute_code::{EXECUTE_CODE_TOOL_NAME, ExecuteCodeTool};
 use serde_json::json;
 use std::time::Duration;
+
+/// Build extensions with a UR5 manifest for execute_code tests.
+fn test_extensions() -> Extensions {
+    let mut ext = Extensions::new();
+    ext.insert(roz_core::channels::ChannelManifest::ur5());
+    ext
+}
 
 fn build_input(user_message: &str) -> AgentInput {
     build_input_with_prompt(
@@ -95,7 +102,7 @@ async fn agent_generates_code_and_wasm_executes() {
 
     let safety = SafetyStack::new(vec![]);
     let spatial = Box::new(MockSpatialContextProvider::empty());
-    let mut agent = AgentLoop::new(model, dispatcher, safety, spatial);
+    let mut agent = AgentLoop::new(model, dispatcher, safety, spatial).with_extensions(test_extensions());
 
     let input = build_input("Wave the arm back and forth");
     let output = agent.run(input).await.expect("agent loop should complete");
@@ -154,7 +161,7 @@ async fn agent_handles_wasm_compilation_failure() {
     dispatcher.register(Box::new(ExecuteCodeTool));
     let safety = SafetyStack::new(vec![]);
     let spatial = Box::new(MockSpatialContextProvider::empty());
-    let mut agent = AgentLoop::new(model, dispatcher, safety, spatial);
+    let mut agent = AgentLoop::new(model, dispatcher, safety, spatial).with_extensions(test_extensions());
 
     let input = build_input("Write a controller");
     let output = agent
@@ -185,7 +192,7 @@ async fn live_model_generates_and_executes_wasm() {
     dispatcher.register(Box::new(ExecuteCodeTool));
     let safety = SafetyStack::new(vec![]);
     let spatial = Box::new(MockSpatialContextProvider::empty());
-    let mut agent = AgentLoop::new(model, dispatcher, safety, spatial);
+    let mut agent = AgentLoop::new(model, dispatcher, safety, spatial).with_extensions(test_extensions());
 
     let input = AgentInput {
         task_id: "live-test".to_string(),

--- a/crates/roz-agent/tests/e2e_code_execution.rs
+++ b/crates/roz-agent/tests/e2e_code_execution.rs
@@ -19,10 +19,13 @@ use roz_agent::tools::execute_code::{EXECUTE_CODE_TOOL_NAME, ExecuteCodeTool};
 use serde_json::json;
 use std::time::Duration;
 
-/// Build extensions with a UR5 manifest for execute_code tests.
+/// Build extensions with a generic 6-joint velocity manifest for execute_code tests.
 fn test_extensions() -> Extensions {
     let mut ext = Extensions::new();
-    ext.insert(roz_core::channels::ChannelManifest::ur5());
+    ext.insert(roz_core::channels::ChannelManifest::generic_velocity(
+        6,
+        std::f64::consts::PI,
+    ));
     ext
 }
 
@@ -373,8 +376,8 @@ Respond with ONLY the WAT code. No explanation, no markdown fences, just raw WAT
     eprintln!("Extracted WAT:\n{wat}");
     assert!(wat.contains("(module"), "response must contain a WAT module");
 
-    // Compile with UR5 manifest (6 command channels, velocity limits).
-    let manifest = roz_core::channels::ChannelManifest::ur5();
+    // Compile with a 6-joint velocity manifest.
+    let manifest = roz_core::channels::ChannelManifest::generic_velocity(6, std::f64::consts::PI);
     let host = roz_copper::wit_host::HostContext::with_manifest(manifest);
     let mut task = roz_copper::wasm::CuWasmTask::from_source_with_host(wat.as_bytes(), host)
         .expect("Claude-generated WAT should compile");

--- a/crates/roz-agent/tests/e2e_wave_arm.rs
+++ b/crates/roz-agent/tests/e2e_wave_arm.rs
@@ -83,7 +83,10 @@ async fn agent_deploys_sin_controller_and_arm_oscillates() {
 
     let mut extensions = Extensions::new();
     extensions.insert(handle.cmd_tx());
-    extensions.insert(roz_core::channels::ChannelManifest::ur5());
+    extensions.insert(roz_core::channels::ChannelManifest::generic_velocity(
+        6,
+        std::f64::consts::PI,
+    ));
 
     // -- 4. ToolDispatcher with deploy_controller registered. ---------------
 

--- a/crates/roz-agent/tests/e2e_wave_arm.rs
+++ b/crates/roz-agent/tests/e2e_wave_arm.rs
@@ -83,6 +83,7 @@ async fn agent_deploys_sin_controller_and_arm_oscillates() {
 
     let mut extensions = Extensions::new();
     extensions.insert(handle.cmd_tx());
+    extensions.insert(roz_core::channels::ChannelManifest::ur5());
 
     // -- 4. ToolDispatcher with deploy_controller registered. ---------------
 

--- a/crates/roz-copper/src/channels.rs
+++ b/crates/roz-copper/src/channels.rs
@@ -49,6 +49,11 @@ pub struct ControllerState {
     /// Entity poses from Gazebo (updated each tick when gazebo feature is active).
     #[serde(default)]
     pub entities: Vec<roz_core::spatial::EntityState>,
+    /// E-stop reason, if an e-stop was triggered by the WASM controller or a
+    /// controller error (trap, epoch timeout, OOM). `None` when healthy.
+    /// The agent's `SpatialContextProvider` can observe this field.
+    #[serde(default)]
+    pub estop_reason: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -58,22 +63,31 @@ pub struct ControllerState {
 /// Bounded channel depth for agent-to-Copper commands.
 const COMMAND_CHANNEL_CAPACITY: usize = 64;
 
-/// Create a command channel (agent -> Copper) and shared state (Copper -> agent).
+/// Return type of [`create_sync_pair`]: command channel, shared state, and e-stop channel.
+pub type SyncPair = (
+    mpsc::Sender<ControllerCommand>,
+    mpsc::Receiver<ControllerCommand>,
+    Arc<ArcSwap<ControllerState>>,
+    mpsc::Sender<String>,
+    mpsc::Receiver<String>,
+);
+
+/// Create command channel, shared state, and e-stop notification channel.
 ///
-/// Returns `(cmd_tx, cmd_rx, shared_state)` where:
+/// Returns [`SyncPair`] `(cmd_tx, cmd_rx, shared_state, estop_tx, estop_rx)` where:
 /// - `cmd_tx` / `cmd_rx` form a bounded `mpsc` channel for
 ///   [`ControllerCommand`] values.
 /// - `shared_state` is an [`ArcSwap`] that the Copper thread
 ///   [`store`](ArcSwap::store)s into and the agent
 ///   [`load`](ArcSwap::load)s from.
-pub fn create_sync_pair() -> (
-    mpsc::Sender<ControllerCommand>,
-    mpsc::Receiver<ControllerCommand>,
-    Arc<ArcSwap<ControllerState>>,
-) {
+/// - `estop_tx` / `estop_rx` carry e-stop reason strings from the
+///   controller loop to the supervisor/adapter. The buffer is small (4)
+///   because e-stops are rare events; overflow is handled via `try_send`.
+pub fn create_sync_pair() -> SyncPair {
     let (cmd_tx, cmd_rx) = mpsc::channel(COMMAND_CHANNEL_CAPACITY);
     let state = Arc::new(ArcSwap::from_pointee(ControllerState::default()));
-    (cmd_tx, cmd_rx, state)
+    let (estop_tx, estop_rx) = mpsc::channel(4);
+    (cmd_tx, cmd_rx, state, estop_tx, estop_rx)
 }
 
 /// Spawn a tokio task that forwards commands from the async agent side
@@ -133,7 +147,7 @@ mod tests {
 
     #[tokio::test]
     async fn command_channel_sends_and_receives() {
-        let (tx, mut rx, _state) = create_sync_pair();
+        let (tx, mut rx, _state, _estop_tx, _estop_rx) = create_sync_pair();
         tx.send(ControllerCommand::Halt).await.unwrap();
         let cmd = rx.recv().await.unwrap();
         assert!(matches!(cmd, ControllerCommand::Halt));
@@ -141,7 +155,7 @@ mod tests {
 
     #[tokio::test]
     async fn command_channel_preserves_order() {
-        let (tx, mut rx, _state) = create_sync_pair();
+        let (tx, mut rx, _state, _estop_tx, _estop_rx) = create_sync_pair();
 
         tx.send(ControllerCommand::Halt).await.unwrap();
         tx.send(ControllerCommand::Resume).await.unwrap();
@@ -156,7 +170,7 @@ mod tests {
 
     #[test]
     fn shared_state_updates_visible() {
-        let (_, _, state) = create_sync_pair();
+        let (_, _, state, _, _) = create_sync_pair();
 
         // Update state (simulating Copper writing).
         state.store(Arc::new(ControllerState {
@@ -164,6 +178,7 @@ mod tests {
             running: true,
             last_output: None,
             entities: vec![],
+            estop_reason: None,
         }));
 
         // Read state (simulating agent reading).
@@ -215,10 +230,49 @@ mod tests {
 
     #[test]
     fn shared_state_defaults_to_idle() {
-        let (_, _, state) = create_sync_pair();
+        let (_, _, state, _, _) = create_sync_pair();
         let current = state.load();
         assert_eq!(current.last_tick, 0);
         assert!(!current.running);
         assert!(current.last_output.is_none());
+        assert!(current.estop_reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn estop_channel_receives_notification() {
+        let (_cmd_tx, _cmd_rx, _state, estop_tx, mut estop_rx) = create_sync_pair();
+        estop_tx
+            .send("e-stop requested by WASM module".to_string())
+            .await
+            .unwrap();
+        let msg = estop_rx.recv().await.unwrap();
+        assert!(msg.contains("e-stop"));
+    }
+
+    #[tokio::test]
+    async fn estop_channel_try_send_does_not_block() {
+        let (_cmd_tx, _cmd_rx, _state, estop_tx, _estop_rx) = create_sync_pair();
+        // Fill the buffer (capacity 4).
+        for i in 0..4 {
+            estop_tx.try_send(format!("error {i}")).unwrap();
+        }
+        // 5th send should fail (full), NOT block.
+        let result = estop_tx.try_send("overflow".to_string());
+        assert!(result.is_err(), "try_send on full estop channel should return Err");
+    }
+
+    #[test]
+    fn estop_reason_in_shared_state() {
+        let (_, _, state, _, _) = create_sync_pair();
+        let reason = "controller_error: wasm trap: unreachable".to_string();
+        state.store(Arc::new(ControllerState {
+            last_tick: 10,
+            running: false,
+            last_output: None,
+            entities: vec![],
+            estop_reason: Some(reason.clone()),
+        }));
+        let current = state.load();
+        assert_eq!(current.estop_reason.as_deref(), Some(reason.as_str()));
     }
 }

--- a/crates/roz-copper/src/controller.rs
+++ b/crates/roz-copper/src/controller.rs
@@ -40,11 +40,7 @@ fn tick_period_from_hz(control_rate_hz: u32) -> Duration {
 ///
 /// Returns `Some(period)` when a new WASM controller is loaded so the caller
 /// can update the loop's tick period and safety filter.
-fn handle_command(
-    cmd: ControllerCommand,
-    wasm_task: &mut Option<CuWasmTask>,
-    running: &mut bool,
-) -> Option<Duration> {
+fn handle_command(cmd: ControllerCommand, wasm_task: &mut Option<CuWasmTask>, running: &mut bool) -> Option<Duration> {
     match cmd {
         ControllerCommand::LoadWasm(bytes, manifest) => {
             let new_period = tick_period_from_hz(manifest.control_rate_hz);
@@ -92,11 +88,105 @@ fn handle_command(
     }
 }
 
+/// Publish current controller state to the shared `ArcSwap`.
+///
+/// Clears `last_output` on idle ticks (not running and no error present)
+/// so the agent does not see stale data.
+fn publish_state(
+    shared_state: &Arc<ArcSwap<ControllerState>>,
+    tick: u64,
+    running: bool,
+    last_output: &mut Option<serde_json::Value>,
+    entities: &[roz_core::spatial::EntityState],
+    estop_reason: Option<&str>,
+) {
+    if !running && last_output.as_ref().is_none_or(|o| o.get("error").is_none()) {
+        *last_output = None;
+    }
+    shared_state.store(Arc::new(ControllerState {
+        last_tick: tick,
+        running,
+        last_output: last_output.clone(),
+        entities: entities.to_vec(),
+        estop_reason: estop_reason.map(String::from),
+    }));
+}
+
+/// Drain emergency and normal command channels, returning whether any
+/// command was received on `cmd_rx` (for watchdog bookkeeping).
+fn drain_commands(
+    cmd_rx: &std::sync::mpsc::Receiver<ControllerCommand>,
+    emergency_rx: Option<&std::sync::mpsc::Receiver<ControllerCommand>>,
+    wasm_task: &mut Option<CuWasmTask>,
+    running: &mut bool,
+    tick_period: &mut Duration,
+    safety_filter: &mut SafetyFilterTask,
+) -> bool {
+    // Emergency channel first (bypasses tokio bridge).
+    if let Some(erx) = emergency_rx {
+        while let Ok(cmd) = erx.try_recv() {
+            if let Some(new_period) = handle_command(cmd, wasm_task, running) {
+                *tick_period = new_period;
+                safety_filter.set_tick_period(new_period.as_secs_f64());
+            }
+        }
+    }
+
+    // Normal command channel.
+    let mut received = false;
+    while let Ok(cmd) = cmd_rx.try_recv() {
+        received = true;
+        if let Some(new_period) = handle_command(cmd, wasm_task, running) {
+            *tick_period = new_period;
+            safety_filter.set_tick_period(new_period.as_secs_f64());
+        }
+    }
+    received
+}
+
+/// Check the agent watchdog timer. If the agent has gone silent for longer
+/// than `timeout`, autonomously halt the controller, send zero velocity to
+/// `zero_sender` (if provided), and fire an estop notification.
+///
+/// Returns `true` when the watchdog fired (caller should skip the WASM tick).
+#[allow(clippy::too_many_arguments)]
+fn check_watchdog(
+    running: &mut bool,
+    last_agent_contact: Instant,
+    timeout: Duration,
+    last_velocity_count: usize,
+    zero_sender: Option<&dyn crate::io::ActuatorSink>,
+    estop_tx: &tokio::sync::mpsc::Sender<String>,
+    estop_reason: &mut Option<String>,
+    last_output: &mut Option<serde_json::Value>,
+) -> bool {
+    if !*running || last_agent_contact.elapsed() <= timeout {
+        return false;
+    }
+    tracing::error!("agent watchdog timeout ({timeout:?}), autonomous halt");
+    *running = false;
+    if let Some(sink) = zero_sender {
+        let _ = sink.send(&CommandFrame::zero(last_velocity_count.max(6)));
+    }
+    let reason = format!(
+        "controller_error: agent watchdog timeout ({}ms)",
+        last_agent_contact.elapsed().as_millis()
+    );
+    let _ = estop_tx.try_send(reason.clone());
+    *estop_reason = Some(reason);
+    *last_output = Some(serde_json::json!({
+        "error": "agent watchdog timeout",
+        "elapsed_ms": last_agent_contact.elapsed().as_millis(),
+    }));
+    true
+}
+
 /// Tick the WASM controller, extract commands, and apply safety filtering.
 ///
 /// Returns the clamped [`CommandFrame`] if any non-default command values
-/// were produced this tick. On WASM trap, sets `running` to `false` and
-/// records the error in `last_output`.
+/// were produced this tick. On WASM trap, sets `running` to `false`,
+/// records the error in `last_output`, and sends the reason through
+/// `estop_tx` so the supervisor/adapter can disable motors.
 ///
 /// # Sensor injection
 ///
@@ -104,12 +194,22 @@ fn handle_command(
 /// via [`CuWasmTask::host_context_mut`] **before** calling this function.
 /// `run_controller_loop` does this automatically when a `SensorSource` is
 /// provided.
+///
+/// # E-stop propagation
+///
+/// Any tick error (explicit `request_estop()`, epoch timeout, OOM, or
+/// generic WASM trap) is sent through `estop_tx` via `try_send` so the
+/// real-time loop is never blocked by a slow receiver. The returned
+/// `estop_reason` is set on the error message for inclusion in
+/// [`ControllerState`].
 fn tick_wasm(
     task: &mut CuWasmTask,
     tick: u64,
     running: &mut bool,
     last_output: &mut Option<serde_json::Value>,
     safety_filter: &mut SafetyFilterTask,
+    estop_tx: &tokio::sync::mpsc::Sender<String>,
+    estop_reason: &mut Option<String>,
 ) -> Option<CommandFrame> {
     match task.tick(tick) {
         Ok(()) => {
@@ -144,10 +244,18 @@ fn tick_wasm(
             Some(clamped)
         }
         Err(e) => {
-            tracing::error!(tick, error = %e, "WASM tick failed, halting");
+            let msg = e.to_string();
+            tracing::error!(tick, error = %msg, "WASM tick failed, halting");
             *running = false;
+
+            // Notify supervisor/adapter of the controller error.
+            // try_send is non-blocking — critical for the real-time loop.
+            let reason = format!("controller_error: {msg}");
+            let _ = estop_tx.try_send(reason.clone());
+            *estop_reason = Some(reason);
+
             *last_output = Some(serde_json::json!({
-                "error": e.to_string(),
+                "error": msg,
                 "tick": tick,
             }));
             None
@@ -195,6 +303,7 @@ pub fn run_controller_loop(
     mut sensor: Option<&mut dyn crate::io::SensorSource>,
     watchdog_timeout: Duration,
     emergency_rx: Option<&std::sync::mpsc::Receiver<ControllerCommand>>,
+    estop_tx: &tokio::sync::mpsc::Sender<String>,
 ) {
     let mut safety_filter = SafetyFilterTask::new(max_velocity, 50.0, None);
     let mut wasm_task: Option<CuWasmTask> = None;
@@ -211,6 +320,9 @@ pub fn run_controller_loop(
     let mut last_agent_contact = Instant::now();
     let mut last_velocity_count: usize = 0;
 
+    // E-stop reason — set on WASM error or watchdog timeout.
+    let mut estop_reason: Option<String> = None;
+
     // Latest sensor data, persisted across ticks until new data arrives.
     let mut entities: Vec<roz_core::spatial::EntityState> = Vec::new();
     let mut sensor_joint_positions: Vec<f64> = Vec::new();
@@ -222,15 +334,21 @@ pub fn run_controller_loop(
     while !shutdown.load(Ordering::Relaxed) {
         let tick_start = Instant::now();
 
-        // --- Drain emergency channel first (bypasses tokio bridge) ---
-        if let Some(erx) = emergency_rx {
-            while let Ok(cmd) = erx.try_recv() {
-                if let Some(new_period) = handle_command(cmd, &mut wasm_task, &mut running) {
-                    tick_period = new_period;
-                    safety_filter.set_tick_period(new_period.as_secs_f64());
-                }
-                last_agent_contact = Instant::now();
-            }
+        // --- Drain commands (emergency first, then normal) ---
+        let received = drain_commands(
+            cmd_rx,
+            emergency_rx,
+            &mut wasm_task,
+            &mut running,
+            &mut tick_period,
+            &mut safety_filter,
+        );
+        if received {
+            last_agent_contact = Instant::now();
+        }
+        // Emergency channel also resets watchdog (any contact counts).
+        if emergency_rx.is_some_and(|_| received) {
+            last_agent_contact = Instant::now();
         }
 
         // --- Read sensor data (non-blocking) ---
@@ -243,49 +361,36 @@ pub fn run_controller_loop(
             sensor_sim_time_ns = frame.sim_time_ns;
         }
 
-        // --- Drain all pending commands (non-blocking) ---
-        let mut received_command = false;
-        while let Ok(cmd) = cmd_rx.try_recv() {
-            received_command = true;
-            if let Some(new_period) = handle_command(cmd, &mut wasm_task, &mut running) {
-                tick_period = new_period;
-                safety_filter.set_tick_period(new_period.as_secs_f64());
-            }
-        }
-        if received_command {
-            last_agent_contact = Instant::now();
-        }
-
-        // --- Agent watchdog — auto-halt if agent goes silent ---
-        if running && last_agent_contact.elapsed() > watchdog_timeout {
-            tracing::error!("agent watchdog timeout ({:?}), autonomous halt", watchdog_timeout);
-            running = false;
-            if let Some(sink) = actuator {
-                let zero_count = last_velocity_count.max(6);
-                let _ = sink.send(&CommandFrame::zero(zero_count));
-            }
-            last_output = Some(serde_json::json!({
-                "error": "agent watchdog timeout",
-                "elapsed_ms": last_agent_contact.elapsed().as_millis(),
-            }));
-        }
+        check_watchdog(
+            &mut running,
+            last_agent_contact,
+            watchdog_timeout,
+            last_velocity_count,
+            actuator,
+            estop_tx,
+            &mut estop_reason,
+            &mut last_output,
+        );
 
         // --- Tick WASM controller ---
         if running && let Some(ref mut task) = wasm_task {
             // Inject latest sensor data into HostContext before WASM tick.
-            // Note: reset_commands() is called inside CuWasmTask::tick().
-            // Concatenate positions + velocities into state_values (matches
-            // UR5 manifest layout: positions 0..N, velocities N..2N).
             let ctx = task.host_context_mut();
             ctx.state_values.clear();
             ctx.state_values.extend_from_slice(&sensor_joint_positions);
             ctx.state_values.extend_from_slice(&sensor_joint_velocities);
             ctx.sim_time_ns = sensor_sim_time_ns;
-
-            // Inject sensor positions for position-limit enforcement.
             safety_filter.update_positions(&sensor_joint_positions);
 
-            if let Some(ref clamped) = tick_wasm(task, tick, &mut running, &mut last_output, &mut safety_filter) {
+            if let Some(ref clamped) = tick_wasm(
+                task,
+                tick,
+                &mut running,
+                &mut last_output,
+                &mut safety_filter,
+                estop_tx,
+                &mut estop_reason,
+            ) {
                 last_velocity_count = clamped.values.len();
                 if let Some(sink) = actuator
                     && let Err(e) = sink.send(clamped)
@@ -295,43 +400,36 @@ pub fn run_controller_loop(
             }
         }
 
-        // --- Publish state (lock-free) ---
-        // Clear last_output on idle ticks (not running, no new output).
-        if !running && last_output.as_ref().is_none_or(|o| o.get("error").is_none()) {
-            last_output = None;
-        }
-        shared_state.store(Arc::new(ControllerState {
-            last_tick: tick,
+        publish_state(
+            shared_state,
+            tick,
             running,
-            last_output: last_output.clone(),
-            entities: entities.clone(),
-        }));
-
+            &mut last_output,
+            &entities,
+            estop_reason.as_deref(),
+        );
         tick += 1;
 
-        // --- Sleep for remainder of tick period ---
         let elapsed = tick_start.elapsed();
         if let Some(remaining) = tick_period.checked_sub(elapsed) {
             std::thread::sleep(remaining);
         }
     }
 
-    // --- Final drain: process any emergency commands that arrived during shutdown ---
-    // This handles the race where Drop sends Halt + sets shutdown simultaneously:
-    // the loop exits on shutdown before draining the emergency channel.
+    // Final drain: process emergency commands that arrived during shutdown.
     if let Some(erx) = emergency_rx {
         while let Ok(cmd) = erx.try_recv() {
             let _ = handle_command(cmd, &mut wasm_task, &mut running);
         }
     }
-    // Publish final state so observers see running=false after emergency halt.
-    shared_state.store(Arc::new(ControllerState {
-        last_tick: tick,
+    publish_state(
+        shared_state,
+        tick,
         running,
-        last_output: last_output.clone(),
-        entities,
-    }));
-
+        &mut last_output,
+        &entities,
+        estop_reason.as_deref(),
+    );
     tracing::info!(total_ticks = tick, "copper controller loop stopped");
 }
 
@@ -367,6 +465,7 @@ pub fn run_controller_loop_with_gazebo(
     mut gazebo: GazeboConfig,
     watchdog_timeout: Duration,
     emergency_rx: Option<&std::sync::mpsc::Receiver<ControllerCommand>>,
+    estop_tx: &tokio::sync::mpsc::Sender<String>,
 ) {
     let mut safety_filter = SafetyFilterTask::new(max_velocity, 50.0, None);
     let mut wasm_task: Option<CuWasmTask> = None;
@@ -383,6 +482,9 @@ pub fn run_controller_loop_with_gazebo(
     let mut last_agent_contact = Instant::now();
     let mut last_velocity_count: usize = 0;
 
+    // E-stop reason — set on WASM error or watchdog timeout.
+    let mut estop_reason: Option<String> = None;
+
     tracing::info!(
         max_velocity,
         ?watchdog_timeout,
@@ -392,43 +494,37 @@ pub fn run_controller_loop_with_gazebo(
     while !shutdown.load(Ordering::Relaxed) {
         let tick_start = Instant::now();
 
-        // --- Drain emergency channel first (bypasses tokio bridge) ---
-        if let Some(erx) = emergency_rx {
-            while let Ok(cmd) = erx.try_recv() {
-                if let Some(new_period) = handle_command(cmd, &mut wasm_task, &mut running) {
-                    tick_period = new_period;
-                    safety_filter.set_tick_period(new_period.as_secs_f64());
-                }
-                last_agent_contact = Instant::now();
-            }
+        // --- Drain commands (emergency first, then normal) ---
+        let received = drain_commands(
+            cmd_rx,
+            emergency_rx,
+            &mut wasm_task,
+            &mut running,
+            &mut tick_period,
+            &mut safety_filter,
+        );
+        if received {
+            last_agent_contact = Instant::now();
         }
 
         // --- Read pose data from Gazebo (non-blocking) ---
-        // Drain all buffered pose messages, keeping only the latest.
         while let Some((pose_v, _meta)) = gazebo.pose_subscriber.try_recv() {
             entities = crate::gazebo_sensor::poses_to_entities(&pose_v);
-        }
-
-        // --- Drain all pending commands (non-blocking) ---
-        let mut received_command = false;
-        while let Ok(cmd) = cmd_rx.try_recv() {
-            received_command = true;
-            if let Some(new_period) = handle_command(cmd, &mut wasm_task, &mut running) {
-                tick_period = new_period;
-                safety_filter.set_tick_period(new_period.as_secs_f64());
-            }
-        }
-        if received_command {
-            last_agent_contact = Instant::now();
         }
 
         // --- Agent watchdog — auto-halt if agent goes silent ---
         if running && last_agent_contact.elapsed() > watchdog_timeout {
             tracing::error!("agent watchdog timeout ({:?}), autonomous halt", watchdog_timeout);
             running = false;
-            // Send zero velocity via Gazebo publisher.
-            let zero_count = last_velocity_count.max(6);
-            let _ = gazebo.joint_publisher.send(&CommandFrame::zero(zero_count));
+            let _ = gazebo
+                .joint_publisher
+                .send(&CommandFrame::zero(last_velocity_count.max(6)));
+            let reason = format!(
+                "controller_error: agent watchdog timeout ({}ms)",
+                last_agent_contact.elapsed().as_millis()
+            );
+            let _ = estop_tx.try_send(reason.clone());
+            estop_reason = Some(reason);
             last_output = Some(serde_json::json!({
                 "error": "agent watchdog timeout",
                 "elapsed_ms": last_agent_contact.elapsed().as_millis(),
@@ -437,8 +533,15 @@ pub fn run_controller_loop_with_gazebo(
 
         // --- Tick WASM controller ---
         if running && let Some(ref mut task) = wasm_task {
-            // Note: reset_commands() is called inside CuWasmTask::tick().
-            if let Some(ref clamped) = tick_wasm(task, tick, &mut running, &mut last_output, &mut safety_filter) {
+            if let Some(ref clamped) = tick_wasm(
+                task,
+                tick,
+                &mut running,
+                &mut last_output,
+                &mut safety_filter,
+                estop_tx,
+                &mut estop_reason,
+            ) {
                 last_velocity_count = clamped.values.len();
                 if let Err(e) = gazebo.joint_publisher.send(clamped) {
                     tracing::warn!(error = %e, "failed to send joint command to Gazebo");
@@ -446,39 +549,36 @@ pub fn run_controller_loop_with_gazebo(
             }
         }
 
-        // --- Publish state (lock-free) ---
-        if !running && last_output.as_ref().is_none_or(|o| o.get("error").is_none()) {
-            last_output = None;
-        }
-        shared_state.store(Arc::new(ControllerState {
-            last_tick: tick,
+        publish_state(
+            shared_state,
+            tick,
             running,
-            last_output: last_output.clone(),
-            entities: entities.clone(),
-        }));
-
+            &mut last_output,
+            &entities,
+            estop_reason.as_deref(),
+        );
         tick += 1;
 
-        // --- Sleep for remainder of tick period ---
         let elapsed = tick_start.elapsed();
         if let Some(remaining) = tick_period.checked_sub(elapsed) {
             std::thread::sleep(remaining);
         }
     }
 
-    // --- Final drain: process any emergency commands that arrived during shutdown ---
+    // Final drain: process emergency commands that arrived during shutdown.
     if let Some(erx) = emergency_rx {
         while let Ok(cmd) = erx.try_recv() {
             let _ = handle_command(cmd, &mut wasm_task, &mut running);
         }
     }
-    shared_state.store(Arc::new(ControllerState {
-        last_tick: tick,
+    publish_state(
+        shared_state,
+        tick,
         running,
-        last_output: last_output.clone(),
-        entities,
-    }));
-
+        &mut last_output,
+        &entities,
+        estop_reason.as_deref(),
+    );
     tracing::info!(total_ticks = tick, "copper controller loop stopped (gazebo)");
 }
 
@@ -510,7 +610,7 @@ mod tests {
         assert_eq!(period, Duration::from_millis(2));
     }
 
-    /// Helper: spawn controller loop, return (tx, state, shutdown, join_handle).
+    /// Helper: spawn controller loop, return (tx, state, shutdown, join_handle, estop_rx).
     fn spawn_controller(
         max_velocity: f64,
     ) -> (
@@ -518,16 +618,28 @@ mod tests {
         Arc<ArcSwap<ControllerState>>,
         Arc<AtomicBool>,
         std::thread::JoinHandle<()>,
+        tokio::sync::mpsc::Receiver<String>,
     ) {
         let (tx, rx) = std::sync::mpsc::sync_channel(64);
         let state = Arc::new(ArcSwap::from_pointee(ControllerState::default()));
         let shutdown = Arc::new(AtomicBool::new(false));
+        let (estop_tx, estop_rx) = tokio::sync::mpsc::channel(4);
         let s = Arc::clone(&state);
         let sd = Arc::clone(&shutdown);
         let handle = std::thread::spawn(move || {
-            run_controller_loop(&rx, &s, max_velocity, &sd, None, None, Duration::from_secs(60), None);
+            run_controller_loop(
+                &rx,
+                &s,
+                max_velocity,
+                &sd,
+                None,
+                None,
+                Duration::from_secs(60),
+                None,
+                &estop_tx,
+            );
         });
-        (tx, state, shutdown, handle)
+        (tx, state, shutdown, handle, estop_rx)
     }
 
     fn stop(shutdown: &Arc<AtomicBool>, handle: std::thread::JoinHandle<()>) {
@@ -539,7 +651,7 @@ mod tests {
 
     #[test]
     fn starts_idle_and_publishes_state() {
-        let (_tx, state, shutdown, handle) = spawn_controller(1.5);
+        let (_tx, state, shutdown, handle, _estop_rx) = spawn_controller(1.5);
         std::thread::sleep(Duration::from_millis(50));
 
         let current = state.load();
@@ -554,7 +666,7 @@ mod tests {
     fn loads_wasm_and_ticks() {
         let wat = r#"(module (func (export "process") (param i64) nop))"#;
         let manifest = roz_core::channels::ChannelManifest::generic_velocity(1, 1.5);
-        let (tx, state, shutdown, handle) = spawn_controller(1.5);
+        let (tx, state, shutdown, handle, _estop_rx) = spawn_controller(1.5);
 
         tx.send(ControllerCommand::LoadWasm(wat.as_bytes().to_vec(), manifest))
             .unwrap();
@@ -575,7 +687,7 @@ mod tests {
     fn halts_on_wasm_trap() {
         let wat = r#"(module (func (export "process") (param i64) unreachable))"#;
         let manifest = roz_core::channels::ChannelManifest::generic_velocity(1, 1.5);
-        let (tx, state, shutdown, handle) = spawn_controller(1.5);
+        let (tx, state, shutdown, handle, _estop_rx) = spawn_controller(1.5);
 
         tx.send(ControllerCommand::LoadWasm(wat.as_bytes().to_vec(), manifest))
             .unwrap();
@@ -604,7 +716,7 @@ mod tests {
             )
         "#;
         let manifest = roz_core::channels::ChannelManifest::generic_velocity(1, 1.5);
-        let (tx, state, shutdown, handle) = spawn_controller(1.5);
+        let (tx, state, shutdown, handle, _estop_rx) = spawn_controller(1.5);
 
         tx.send(ControllerCommand::LoadWasm(wat.as_bytes().to_vec(), manifest))
             .unwrap();
@@ -637,7 +749,7 @@ mod tests {
             )
         "#;
         let manifest = roz_core::channels::ChannelManifest::generic_velocity(1, 1.5);
-        let (tx, state, shutdown, handle) = spawn_controller(1.5);
+        let (tx, state, shutdown, handle, _estop_rx) = spawn_controller(1.5);
 
         tx.send(ControllerCommand::LoadWasm(wat.as_bytes().to_vec(), manifest))
             .unwrap();
@@ -671,7 +783,7 @@ mod tests {
             )
         "#;
         let manifest = roz_core::channels::ChannelManifest::generic_velocity(1, 1.5);
-        let (tx, state, shutdown, handle) = spawn_controller(1.5);
+        let (tx, state, shutdown, handle, _estop_rx) = spawn_controller(1.5);
 
         tx.send(ControllerCommand::LoadWasm(wat.as_bytes().to_vec(), manifest))
             .unwrap();
@@ -701,7 +813,7 @@ mod tests {
             )
         "#;
         let manifest = roz_core::channels::ChannelManifest::generic_velocity(3, 1.5);
-        let (tx, state, shutdown, handle) = spawn_controller(1.5);
+        let (tx, state, shutdown, handle, _estop_rx) = spawn_controller(1.5);
 
         tx.send(ControllerCommand::LoadWasm(wat.as_bytes().to_vec(), manifest))
             .unwrap();
@@ -737,7 +849,7 @@ mod tests {
             )
         "#;
         let manifest = roz_core::channels::ChannelManifest::generic_velocity(1, 1.5);
-        let (tx, state, shutdown, handle) = spawn_controller(1.5);
+        let (tx, state, shutdown, handle, _estop_rx) = spawn_controller(1.5);
 
         tx.send(ControllerCommand::LoadWasm(wat.as_bytes().to_vec(), manifest))
             .unwrap();
@@ -766,7 +878,7 @@ mod tests {
             )
         "#;
         let manifest = roz_core::channels::ChannelManifest::generic_velocity(1, 1.5);
-        let (tx, state, shutdown, handle) = spawn_controller(1.5);
+        let (tx, state, shutdown, handle, _estop_rx) = spawn_controller(1.5);
 
         tx.send(ControllerCommand::LoadWasm(wat.as_bytes().to_vec(), manifest))
             .unwrap();
@@ -810,7 +922,7 @@ mod tests {
             )
         "#;
 
-        let (tx, state, shutdown, handle) = spawn_controller(1.5);
+        let (tx, state, shutdown, handle, _estop_rx) = spawn_controller(1.5);
 
         let manifest = roz_core::channels::ChannelManifest::generic_velocity(1, 1.5);
         tx.send(ControllerCommand::LoadWasm(wat_slow.as_bytes().to_vec(), manifest))
@@ -847,7 +959,7 @@ mod tests {
             )
         "#;
         let manifest = roz_core::channels::ChannelManifest::generic_velocity(1, 1.5);
-        let (tx, state, shutdown, handle) = spawn_controller(1.5);
+        let (tx, state, shutdown, handle, _estop_rx) = spawn_controller(1.5);
 
         tx.send(ControllerCommand::LoadWasm(wat.as_bytes().to_vec(), manifest))
             .unwrap();
@@ -858,6 +970,65 @@ mod tests {
         let output = current.last_output.as_ref().expect("should have error output");
         let err = output["error"].as_str().unwrap();
         assert!(err.contains("e-stop"), "error should mention e-stop: {err}");
+
+        // estop_reason should be set in shared state for agent observability.
+        let reason = current.estop_reason.as_ref().expect("estop_reason should be set");
+        assert!(
+            reason.contains("e-stop"),
+            "estop_reason should mention e-stop: {reason}"
+        );
+
+        stop(&shutdown, handle);
+    }
+
+    #[test]
+    fn estop_channel_notified_on_wasm_trap() {
+        // WASM module that traps immediately (unreachable).
+        let wat = r#"(module (func (export "process") (param i64) unreachable))"#;
+        let manifest = roz_core::channels::ChannelManifest::generic_velocity(1, 1.5);
+        let (tx, state, shutdown, handle, mut estop_rx) = spawn_controller(1.5);
+
+        tx.send(ControllerCommand::LoadWasm(wat.as_bytes().to_vec(), manifest))
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(200));
+
+        // Controller should have halted.
+        assert!(!state.load().running, "should halt after trap");
+
+        // Estop channel should have received a notification (non-blocking check).
+        let msg = estop_rx.try_recv().expect("estop channel should have a message");
+        assert!(
+            msg.starts_with("controller_error:"),
+            "estop message should be prefixed with controller_error: got {msg}"
+        );
+
+        // estop_reason in shared state should match.
+        let reason = state.load().estop_reason.clone().expect("estop_reason should be set");
+        assert_eq!(reason, msg, "shared state reason should match channel message");
+
+        stop(&shutdown, handle);
+    }
+
+    #[test]
+    fn estop_channel_notified_on_explicit_estop() {
+        // WASM module that calls request_estop().
+        let wat = r#"
+            (module
+                (import "safety" "request_estop" (func $estop))
+                (func (export "process") (param i64) (call $estop))
+            )
+        "#;
+        let manifest = roz_core::channels::ChannelManifest::generic_velocity(1, 1.5);
+        let (tx, _state, shutdown, handle, mut estop_rx) = spawn_controller(1.5);
+
+        tx.send(ControllerCommand::LoadWasm(wat.as_bytes().to_vec(), manifest))
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(200));
+
+        let msg = estop_rx
+            .try_recv()
+            .expect("estop channel should have a message for explicit e-stop");
+        assert!(msg.contains("e-stop"), "estop message should mention e-stop: {msg}");
 
         stop(&shutdown, handle);
     }
@@ -880,10 +1051,21 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::sync_channel(64);
         let state = Arc::new(ArcSwap::from_pointee(ControllerState::default()));
         let shutdown = Arc::new(AtomicBool::new(false));
+        let (estop_tx, _estop_rx) = tokio::sync::mpsc::channel(4);
         let s = Arc::clone(&state);
         let sd = Arc::clone(&shutdown);
         let handle = std::thread::spawn(move || {
-            run_controller_loop(&rx, &s, 1.5, &sd, Some(&*sink_ref), None, Duration::from_secs(60), None);
+            run_controller_loop(
+                &rx,
+                &s,
+                1.5,
+                &sd,
+                Some(&*sink_ref),
+                None,
+                Duration::from_secs(60),
+                None,
+                &estop_tx,
+            );
         });
 
         let manifest = roz_core::channels::ChannelManifest::generic_velocity(1, 1.5);
@@ -932,6 +1114,7 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::sync_channel(64);
         let state = Arc::new(ArcSwap::from_pointee(ControllerState::default()));
         let shutdown = Arc::new(AtomicBool::new(false));
+        let (estop_tx, _estop_rx) = tokio::sync::mpsc::channel(4);
         let s = Arc::clone(&state);
         let sd = Arc::clone(&shutdown);
         let handle = std::thread::spawn(move || {
@@ -944,6 +1127,7 @@ mod tests {
                 Some(&mut source),
                 Duration::from_secs(60),
                 None,
+                &estop_tx,
             );
         });
 
@@ -993,6 +1177,7 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::sync_channel(64);
         let state = Arc::new(ArcSwap::from_pointee(ControllerState::default()));
         let shutdown = Arc::new(AtomicBool::new(false));
+        let (estop_tx, _estop_rx) = tokio::sync::mpsc::channel(4);
         let s = Arc::clone(&state);
         let sd = Arc::clone(&shutdown);
 
@@ -1007,6 +1192,7 @@ mod tests {
                 None,
                 Duration::from_millis(100),
                 None,
+                &estop_tx,
             );
         });
 

--- a/crates/roz-copper/src/controller.rs
+++ b/crates/roz-copper/src/controller.rs
@@ -1,6 +1,8 @@
 //! Real-time Copper controller loop.
 //!
-//! Runs on a dedicated thread at ~100 Hz. Drains commands from a
+//! Runs on a dedicated thread at the rate specified by the loaded
+//! [`ChannelManifest`](roz_core::channels::ChannelManifest) (defaults to
+//! 100 Hz when no manifest is loaded). Drains commands from a
 //! `std::sync::mpsc` channel (non-blocking), ticks the WASM controller,
 //! applies safety filtering, and publishes state via `ArcSwap`.
 
@@ -16,20 +18,41 @@ use crate::channels::{ControllerCommand, ControllerState};
 use crate::safety_filter::SafetyFilterTask;
 use crate::wasm::CuWasmTask;
 
-/// Target tick rate: 100 Hz = 10 ms per tick.
-const TICK_PERIOD: Duration = Duration::from_millis(10);
+/// Default tick rate: 100 Hz = 10 ms per tick.
+///
+/// Used when no WASM controller (and thus no [`ChannelManifest`]) is loaded.
+/// Once a manifest is loaded, the tick period is derived from
+/// [`ChannelManifest::control_rate_hz`].
+const DEFAULT_TICK_PERIOD: Duration = Duration::from_millis(10);
 
 // ---------------------------------------------------------------------------
 // Shared helpers (used by both plain and Gazebo controller loops)
 // ---------------------------------------------------------------------------
 
+/// Derive the tick period from a manifest's `control_rate_hz`.
+///
+/// Returns [`DEFAULT_TICK_PERIOD`] when the rate is zero (division guard).
+fn tick_period_from_hz(control_rate_hz: u32) -> Duration {
+    Duration::from_millis(1000 / u64::from(control_rate_hz.max(1)))
+}
+
 /// Process a single [`ControllerCommand`], updating wasm task and running state.
-fn handle_command(cmd: ControllerCommand, wasm_task: &mut Option<CuWasmTask>, running: &mut bool) {
+///
+/// Returns `Some(period)` when a new WASM controller is loaded so the caller
+/// can update the loop's tick period and safety filter.
+fn handle_command(
+    cmd: ControllerCommand,
+    wasm_task: &mut Option<CuWasmTask>,
+    running: &mut bool,
+) -> Option<Duration> {
     match cmd {
         ControllerCommand::LoadWasm(bytes, manifest) => {
+            let new_period = tick_period_from_hz(manifest.control_rate_hz);
             tracing::info!(
                 bytes = bytes.len(),
                 channels = manifest.command_count(),
+                control_rate_hz = manifest.control_rate_hz,
+                tick_period_ms = new_period.as_millis(),
                 "loading new WASM controller"
             );
             let host_ctx = crate::wit_host::HostContext::with_manifest(manifest);
@@ -38,17 +61,20 @@ fn handle_command(cmd: ControllerCommand, wasm_task: &mut Option<CuWasmTask>, ru
                     *wasm_task = Some(task);
                     *running = true;
                     tracing::info!("WASM controller loaded and running");
+                    Some(new_period)
                 }
                 Err(e) => {
                     tracing::error!(error = %e, "failed to load WASM controller");
                     *wasm_task = None;
                     *running = false;
+                    None
                 }
             }
         }
         ControllerCommand::Halt => {
             tracing::info!("controller halted");
             *running = false;
+            None
         }
         ControllerCommand::Resume => {
             if wasm_task.is_some() {
@@ -57,9 +83,11 @@ fn handle_command(cmd: ControllerCommand, wasm_task: &mut Option<CuWasmTask>, ru
             } else {
                 tracing::warn!("resume ignored — no WASM controller loaded");
             }
+            None
         }
         ControllerCommand::UpdateParams(params) => {
             tracing::debug!(?params, "controller params update (not yet implemented)");
+            None
         }
     }
 }
@@ -175,6 +203,10 @@ pub fn run_controller_loop(
     // Persists across ticks so error/halt state is readable by the agent.
     let mut last_output: Option<serde_json::Value> = None;
 
+    // Tick period — starts at the default (100 Hz) and updates when a manifest
+    // is loaded via `LoadWasm`.
+    let mut tick_period = DEFAULT_TICK_PERIOD;
+
     // Agent watchdog state.
     let mut last_agent_contact = Instant::now();
     let mut last_velocity_count: usize = 0;
@@ -193,7 +225,10 @@ pub fn run_controller_loop(
         // --- Drain emergency channel first (bypasses tokio bridge) ---
         if let Some(erx) = emergency_rx {
             while let Ok(cmd) = erx.try_recv() {
-                handle_command(cmd, &mut wasm_task, &mut running);
+                if let Some(new_period) = handle_command(cmd, &mut wasm_task, &mut running) {
+                    tick_period = new_period;
+                    safety_filter.set_tick_period(new_period.as_secs_f64());
+                }
                 last_agent_contact = Instant::now();
             }
         }
@@ -212,7 +247,10 @@ pub fn run_controller_loop(
         let mut received_command = false;
         while let Ok(cmd) = cmd_rx.try_recv() {
             received_command = true;
-            handle_command(cmd, &mut wasm_task, &mut running);
+            if let Some(new_period) = handle_command(cmd, &mut wasm_task, &mut running) {
+                tick_period = new_period;
+                safety_filter.set_tick_period(new_period.as_secs_f64());
+            }
         }
         if received_command {
             last_agent_contact = Instant::now();
@@ -273,7 +311,7 @@ pub fn run_controller_loop(
 
         // --- Sleep for remainder of tick period ---
         let elapsed = tick_start.elapsed();
-        if let Some(remaining) = TICK_PERIOD.checked_sub(elapsed) {
+        if let Some(remaining) = tick_period.checked_sub(elapsed) {
             std::thread::sleep(remaining);
         }
     }
@@ -283,7 +321,7 @@ pub fn run_controller_loop(
     // the loop exits on shutdown before draining the emergency channel.
     if let Some(erx) = emergency_rx {
         while let Ok(cmd) = erx.try_recv() {
-            handle_command(cmd, &mut wasm_task, &mut running);
+            let _ = handle_command(cmd, &mut wasm_task, &mut running);
         }
     }
     // Publish final state so observers see running=false after emergency halt.
@@ -337,6 +375,10 @@ pub fn run_controller_loop_with_gazebo(
     let mut last_output: Option<serde_json::Value> = None;
     let mut entities: Vec<roz_core::spatial::EntityState> = Vec::new();
 
+    // Tick period — starts at the default (100 Hz) and updates when a manifest
+    // is loaded via `LoadWasm`.
+    let mut tick_period = DEFAULT_TICK_PERIOD;
+
     // Agent watchdog state.
     let mut last_agent_contact = Instant::now();
     let mut last_velocity_count: usize = 0;
@@ -353,7 +395,10 @@ pub fn run_controller_loop_with_gazebo(
         // --- Drain emergency channel first (bypasses tokio bridge) ---
         if let Some(erx) = emergency_rx {
             while let Ok(cmd) = erx.try_recv() {
-                handle_command(cmd, &mut wasm_task, &mut running);
+                if let Some(new_period) = handle_command(cmd, &mut wasm_task, &mut running) {
+                    tick_period = new_period;
+                    safety_filter.set_tick_period(new_period.as_secs_f64());
+                }
                 last_agent_contact = Instant::now();
             }
         }
@@ -368,7 +413,10 @@ pub fn run_controller_loop_with_gazebo(
         let mut received_command = false;
         while let Ok(cmd) = cmd_rx.try_recv() {
             received_command = true;
-            handle_command(cmd, &mut wasm_task, &mut running);
+            if let Some(new_period) = handle_command(cmd, &mut wasm_task, &mut running) {
+                tick_period = new_period;
+                safety_filter.set_tick_period(new_period.as_secs_f64());
+            }
         }
         if received_command {
             last_agent_contact = Instant::now();
@@ -413,7 +461,7 @@ pub fn run_controller_loop_with_gazebo(
 
         // --- Sleep for remainder of tick period ---
         let elapsed = tick_start.elapsed();
-        if let Some(remaining) = TICK_PERIOD.checked_sub(elapsed) {
+        if let Some(remaining) = tick_period.checked_sub(elapsed) {
             std::thread::sleep(remaining);
         }
     }
@@ -421,7 +469,7 @@ pub fn run_controller_loop_with_gazebo(
     // --- Final drain: process any emergency commands that arrived during shutdown ---
     if let Some(erx) = emergency_rx {
         while let Ok(cmd) = erx.try_recv() {
-            handle_command(cmd, &mut wasm_task, &mut running);
+            let _ = handle_command(cmd, &mut wasm_task, &mut running);
         }
     }
     shared_state.store(Arc::new(ControllerState {
@@ -437,6 +485,30 @@ pub fn run_controller_loop_with_gazebo(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tick_period_from_manifest() {
+        use roz_core::channels::ChannelManifest;
+
+        // Default manifest: 100 Hz -> 10 ms
+        let manifest = ChannelManifest::default();
+        let period = tick_period_from_hz(manifest.control_rate_hz);
+        assert_eq!(period, Duration::from_millis(10));
+
+        // Reachy Mini at 50 Hz -> 20 ms
+        let mut mini_manifest = ChannelManifest::default();
+        mini_manifest.control_rate_hz = 50;
+        let period = tick_period_from_hz(mini_manifest.control_rate_hz);
+        assert_eq!(period, Duration::from_millis(20));
+
+        // Edge case: 0 Hz should not panic, falls back to 1 Hz -> 1000 ms
+        let period = tick_period_from_hz(0);
+        assert_eq!(period, Duration::from_millis(1000));
+
+        // High rate: 500 Hz -> 2 ms
+        let period = tick_period_from_hz(500);
+        assert_eq!(period, Duration::from_millis(2));
+    }
 
     /// Helper: spawn controller loop, return (tx, state, shutdown, join_handle).
     fn spawn_controller(

--- a/crates/roz-copper/src/controller.rs
+++ b/crates/roz-copper/src/controller.rs
@@ -82,7 +82,13 @@ fn handle_command(cmd: ControllerCommand, wasm_task: &mut Option<CuWasmTask>, ru
             None
         }
         ControllerCommand::UpdateParams(params) => {
-            tracing::debug!(?params, "controller params update (not yet implemented)");
+            if let Some(ref mut task) = *wasm_task {
+                let json_bytes = serde_json::to_vec(&params).unwrap_or_default();
+                task.host_context_mut().config_json = json_bytes;
+                tracing::debug!("controller params updated");
+            } else {
+                tracing::warn!("UpdateParams ignored — no WASM controller loaded");
+            }
             None
         }
     }

--- a/crates/roz-copper/src/handle.rs
+++ b/crates/roz-copper/src/handle.rs
@@ -39,6 +39,10 @@ pub struct CopperHandle {
     thread: Option<std::thread::JoinHandle<()>>,
     /// Bridge task handle.
     bridge: Option<tokio::task::JoinHandle<()>>,
+    /// E-stop notification receiver. The controller loop sends a reason string
+    /// through this channel when a WASM error or watchdog timeout occurs.
+    /// The supervisor/adapter should drain this and call `emergency_stop` on hardware.
+    estop_rx: Option<mpsc::Receiver<String>>,
 }
 
 impl CopperHandle {
@@ -64,6 +68,9 @@ impl CopperHandle {
         // Shutdown flag.
         let shutdown = Arc::new(AtomicBool::new(false));
 
+        // E-stop notification channel.
+        let (estop_tx, estop_rx) = mpsc::channel::<String>(4);
+
         // Spawn bridge task (tokio → std forwarding).
         let bridge = crate::channels::spawn_command_bridge(agent_rx, copper_tx);
 
@@ -82,6 +89,7 @@ impl CopperHandle {
                     None,
                     AGENT_WATCHDOG_TIMEOUT,
                     Some(&emergency_rx),
+                    &estop_tx,
                 );
             })
             .expect("failed to spawn copper controller thread");
@@ -93,6 +101,7 @@ impl CopperHandle {
             shutdown,
             thread: Some(thread),
             bridge: Some(bridge),
+            estop_rx: Some(estop_rx),
         }
     }
 
@@ -124,6 +133,9 @@ impl CopperHandle {
         // Shutdown flag.
         let shutdown = Arc::new(AtomicBool::new(false));
 
+        // E-stop notification channel.
+        let (estop_tx, estop_rx) = mpsc::channel::<String>(4);
+
         // Spawn bridge task (tokio → std forwarding).
         let bridge = crate::channels::spawn_command_bridge(agent_rx, copper_tx);
 
@@ -153,6 +165,7 @@ impl CopperHandle {
                             Some(&mut *s),
                             AGENT_WATCHDOG_TIMEOUT,
                             Some(&emergency_rx),
+                            &estop_tx,
                         );
                     }
                     None => {
@@ -165,6 +178,7 @@ impl CopperHandle {
                             None,
                             AGENT_WATCHDOG_TIMEOUT,
                             Some(&emergency_rx),
+                            &estop_tx,
                         );
                     }
                 }
@@ -178,6 +192,7 @@ impl CopperHandle {
             shutdown,
             thread: Some(thread),
             bridge: Some(bridge),
+            estop_rx: Some(estop_rx),
         }
     }
 
@@ -200,6 +215,16 @@ impl CopperHandle {
     /// Get the shared state handle (for `CopperSpatialProvider`).
     pub const fn state(&self) -> &Arc<ArcSwap<ControllerState>> {
         &self.state
+    }
+
+    /// Take the e-stop receiver (can only be called once).
+    ///
+    /// The supervisor or hardware adapter should drain this channel and
+    /// call `emergency_stop()` / `disable_motors()` on the hardware when
+    /// a message arrives. Messages are reason strings describing the error
+    /// (e.g. `"controller_error: e-stop requested by WASM module"`).
+    pub const fn take_estop_rx(&mut self) -> Option<mpsc::Receiver<String>> {
+        self.estop_rx.take()
     }
 
     /// Cleanly shut down the Copper thread and bridge task.

--- a/crates/roz-copper/src/lib.rs
+++ b/crates/roz-copper/src/lib.rs
@@ -26,6 +26,7 @@ pub mod io_log;
 pub mod manifest;
 pub mod mcap_export;
 pub mod safety_filter;
+pub mod state_injector;
 pub mod tasks;
 pub mod wasm;
 pub mod wit_host;

--- a/crates/roz-copper/src/manifest.rs
+++ b/crates/roz-copper/src/manifest.rs
@@ -367,7 +367,14 @@ limits = [-3.14, 3.14]
 
             // Verify head/orientation.yaw has max_delta_from body/yaw
             assert_eq!(ch.commands[5].name, "head/orientation.yaw");
-            assert_eq!(ch.commands[5].max_delta_from, Some((6, 1.1345)));
+            // 65 degrees in radians = 1.1344640137963142
+            let expected_delta = 65.0_f64.to_radians();
+            let (idx, delta) = ch.commands[5].max_delta_from.unwrap();
+            assert_eq!(idx, 6);
+            assert!(
+                (delta - expected_delta).abs() < 1e-10,
+                "max_delta_from delta should be 65 deg in radians: got {delta}, expected {expected_delta}"
+            );
 
             // All channels are position type
             assert!(

--- a/crates/roz-copper/src/manifest.rs
+++ b/crates/roz-copper/src/manifest.rs
@@ -18,6 +18,9 @@ pub struct RobotManifest {
     pub sensors: Vec<Sensor>,
     /// Safety parameters.
     pub safety: Option<SafetyConfig>,
+    /// Channel manifest for the WASM controller interface.
+    /// If present, used to build the [`roz_core::channels::ChannelManifest`] for this robot.
+    pub channels: Option<ChannelConfig>,
 }
 
 /// Robot identity metadata.
@@ -62,6 +65,49 @@ pub struct Sensor {
     pub rate_hz: Option<u32>,
 }
 
+/// Channel configuration section of `robot.toml`.
+///
+/// Maps directly to [`roz_core::channels::ChannelManifest`] via
+/// [`RobotManifest::channel_manifest`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelConfig {
+    /// Robot identifier (matches `ChannelManifest::robot_id`).
+    pub robot_id: String,
+    /// Robot class (e.g. `"manipulator"`, `"expressive"`, `"drone"`).
+    pub robot_class: String,
+    /// Control loop rate in Hz.
+    pub control_rate_hz: u32,
+    /// Command channels (written by the controller each tick).
+    #[serde(default)]
+    pub commands: Vec<ChannelDef>,
+    /// State channels (read by the controller each tick).
+    #[serde(default)]
+    pub states: Vec<ChannelDef>,
+}
+
+/// A single channel definition in `robot.toml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelDef {
+    /// Channel name (`ros2_control` convention: `"joint_name/interface_type"`).
+    pub name: String,
+    /// `"position"`, `"velocity"`, or `"effort"`.
+    #[serde(rename = "type")]
+    pub interface_type: String,
+    /// Physical unit string (e.g. `"rad"`, `"m"`, `"rad/s"`).
+    pub unit: String,
+    /// `[min, max]` value limits.
+    pub limits: [f64; 2],
+    /// Safe default value (usually `0.0`).
+    #[serde(default)]
+    pub default: f64,
+    /// Max rate of change per tick for acceleration/jerk limiting.
+    pub max_rate_of_change: Option<f64>,
+    /// Index of the corresponding position state channel.
+    pub position_state_index: Option<usize>,
+    /// Cross-channel delta constraint: `[other_command_index, max_delta]`.
+    pub max_delta_from: Option<[f64; 2]>,
+}
+
 /// Safety configuration for the robot.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SafetyConfig {
@@ -85,6 +131,51 @@ impl RobotManifest {
         let contents = std::fs::read_to_string(path)?;
         let manifest: Self = toml::from_str(&contents)?;
         Ok(manifest)
+    }
+
+    /// Build a [`roz_core::channels::ChannelManifest`] from the `[channels]` section.
+    ///
+    /// Returns `None` if no `[channels]` section is present in the manifest.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an `interface_type` string is not one of `"position"`, `"velocity"`, or `"effort"`.
+    #[must_use]
+    pub fn channel_manifest(&self) -> Option<roz_core::channels::ChannelManifest> {
+        use roz_core::channels::{ChannelDescriptor, ChannelManifest, InterfaceType};
+
+        let ch = self.channels.as_ref()?;
+
+        let convert = |def: &ChannelDef| -> ChannelDescriptor {
+            let interface_type = match def.interface_type.as_str() {
+                "position" => InterfaceType::Position,
+                "velocity" => InterfaceType::Velocity,
+                "effort" => InterfaceType::Effort,
+                other => panic!("unknown interface_type in robot.toml: {other:?}"),
+            };
+            ChannelDescriptor {
+                name: def.name.clone(),
+                interface_type,
+                unit: def.unit.clone(),
+                limits: (def.limits[0], def.limits[1]),
+                default: def.default,
+                max_rate_of_change: def.max_rate_of_change,
+                position_state_index: def.position_state_index,
+                max_delta_from: def.max_delta_from.map(|[idx, delta]| {
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    let index = idx as usize;
+                    (index, delta)
+                }),
+            }
+        };
+
+        Some(ChannelManifest {
+            robot_id: ch.robot_id.clone(),
+            robot_class: ch.robot_class.clone(),
+            control_rate_hz: ch.control_rate_hz,
+            commands: ch.commands.iter().map(convert).collect(),
+            states: ch.states.iter().map(convert).collect(),
+        })
     }
 
     /// Render as a concise system prompt block (~400-500 tokens).
@@ -183,5 +274,107 @@ watchdog_timeout_ms = 500
         assert!(prompt.contains("arm"));
         assert!(prompt.contains("imu"));
         assert!(prompt.contains("80N"));
+    }
+
+    #[test]
+    fn channel_manifest_from_robot_toml() {
+        let toml_str = r#"
+[robot]
+name = "test"
+description = "test"
+
+[channels]
+robot_id = "test"
+robot_class = "test"
+control_rate_hz = 50
+
+[[channels.commands]]
+name = "joint/position"
+type = "position"
+unit = "rad"
+limits = [-1.0, 1.0]
+position_state_index = 0
+
+[[channels.states]]
+name = "joint/position"
+type = "position"
+unit = "rad"
+limits = [-1.0, 1.0]
+"#;
+        let manifest: RobotManifest = toml::from_str(toml_str).unwrap();
+        let ch = manifest.channel_manifest().unwrap();
+        assert_eq!(ch.robot_id, "test");
+        assert_eq!(ch.control_rate_hz, 50);
+        assert_eq!(ch.commands.len(), 1);
+        assert_eq!(ch.states.len(), 1);
+        assert_eq!(
+            ch.commands[0].interface_type,
+            roz_core::channels::InterfaceType::Position
+        );
+        assert_eq!(ch.commands[0].limits, (-1.0, 1.0));
+        assert_eq!(ch.commands[0].position_state_index, Some(0));
+    }
+
+    #[test]
+    fn channel_manifest_none_when_no_channels_section() {
+        let manifest: RobotManifest = toml::from_str(EXAMPLE_TOML).unwrap();
+        assert!(manifest.channel_manifest().is_none());
+    }
+
+    #[test]
+    fn channel_manifest_with_max_delta_from() {
+        let toml_str = r#"
+[robot]
+name = "test"
+description = "test"
+
+[channels]
+robot_id = "test"
+robot_class = "test"
+control_rate_hz = 100
+
+[[channels.commands]]
+name = "a/position"
+type = "position"
+unit = "rad"
+limits = [-3.14, 3.14]
+max_delta_from = [1, 1.5]
+
+[[channels.commands]]
+name = "b/position"
+type = "position"
+unit = "rad"
+limits = [-3.14, 3.14]
+"#;
+        let manifest: RobotManifest = toml::from_str(toml_str).unwrap();
+        let ch = manifest.channel_manifest().unwrap();
+        assert_eq!(ch.commands[0].max_delta_from, Some((1, 1.5)));
+        assert_eq!(ch.commands[1].max_delta_from, None);
+    }
+
+    #[test]
+    fn reachy_mini_robot_toml_loads() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/reachy-mini/robot.toml");
+        if path.exists() {
+            let manifest = RobotManifest::load(&path).unwrap();
+            assert_eq!(manifest.robot.name, "reachy-mini");
+            let ch = manifest.channel_manifest().unwrap();
+            assert_eq!(ch.robot_id, "reachy_mini");
+            assert_eq!(ch.robot_class, "expressive");
+            assert_eq!(ch.control_rate_hz, 50);
+            assert_eq!(ch.commands.len(), 9);
+            assert_eq!(ch.states.len(), 9);
+
+            // Verify head/orientation.yaw has max_delta_from body/yaw
+            assert_eq!(ch.commands[5].name, "head/orientation.yaw");
+            assert_eq!(ch.commands[5].max_delta_from, Some((6, 1.1345)));
+
+            // All channels are position type
+            assert!(
+                ch.commands
+                    .iter()
+                    .all(|c| c.interface_type == roz_core::channels::InterfaceType::Position)
+            );
+        }
     }
 }

--- a/crates/roz-copper/src/safety_filter.rs
+++ b/crates/roz-copper/src/safety_filter.rs
@@ -476,6 +476,7 @@ mod tests {
                 default: 0.0,
                 max_rate_of_change: None,
                 position_state_index: Some(0),
+                max_delta_from: None,
             }],
             states: vec![ChannelDescriptor {
                 name: "joint/position".into(),
@@ -485,6 +486,7 @@ mod tests {
                 default: 0.0,
                 max_rate_of_change: None,
                 position_state_index: None,
+                max_delta_from: None,
             }],
         };
 
@@ -522,6 +524,7 @@ mod tests {
                 default: 0.0,
                 max_rate_of_change: None,
                 position_state_index: Some(0),
+                max_delta_from: None,
             }],
             states: vec![ChannelDescriptor {
                 name: "joint/position".into(),
@@ -531,6 +534,7 @@ mod tests {
                 default: 0.0,
                 max_rate_of_change: None,
                 position_state_index: None,
+                max_delta_from: None,
             }],
         };
 

--- a/crates/roz-copper/src/safety_filter.rs
+++ b/crates/roz-copper/src/safety_filter.rs
@@ -60,6 +60,14 @@ impl SafetyFilterTask {
         }
     }
 
+    /// Update the tick period used for acceleration limiting.
+    ///
+    /// Called when a new [`ChannelManifest`] is loaded and the control rate
+    /// changes (e.g. 100 Hz -> 50 Hz).
+    pub fn set_tick_period(&mut self, period_secs: f64) {
+        self.tick_period = period_secs;
+    }
+
     /// Update known joint positions from sensor feedback.
     ///
     /// Call before [`clamp`](Self::clamp) each tick for position limit enforcement.
@@ -538,6 +546,36 @@ mod tests {
             clamped.values[0], 0.0,
             "velocity channel should zero at boundary, got {}",
             clamped.values[0]
+        );
+    }
+
+    #[test]
+    fn set_tick_period_affects_acceleration_limit() {
+        // At 100 Hz (0.01 s): max_delta = 50 * 0.01 = 0.5 rad/s per tick
+        let mut filter = SafetyFilterTask::new(1.5, 50.0, None);
+
+        let cmd = MotorCommand {
+            joint_velocities: vec![1.5],
+            joint_positions: None,
+            control_mode: ControlMode::Velocity,
+        };
+        let clamped = filter.clamp(&cmd);
+        assert!(
+            (clamped.joint_velocities[0] - 0.5).abs() < 0.01,
+            "at 100 Hz, max delta should be 0.5: got {}",
+            clamped.joint_velocities[0]
+        );
+
+        // Switch to 50 Hz (0.02 s): max_delta = 50 * 0.02 = 1.0 rad/s per tick
+        // Reset prev_velocities so we start from zero again.
+        let mut filter = SafetyFilterTask::new(1.5, 50.0, None);
+        filter.set_tick_period(0.02);
+
+        let clamped = filter.clamp(&cmd);
+        assert!(
+            (clamped.joint_velocities[0] - 1.0).abs() < 0.01,
+            "at 50 Hz, max delta should be 1.0: got {}",
+            clamped.joint_velocities[0]
         );
     }
 

--- a/crates/roz-copper/src/safety_filter.rs
+++ b/crates/roz-copper/src/safety_filter.rs
@@ -64,7 +64,7 @@ impl SafetyFilterTask {
     ///
     /// Called when a new [`ChannelManifest`] is loaded and the control rate
     /// changes (e.g. 100 Hz -> 50 Hz).
-    pub fn set_tick_period(&mut self, period_secs: f64) {
+    pub const fn set_tick_period(&mut self, period_secs: f64) {
         self.tick_period = period_secs;
     }
 

--- a/crates/roz-copper/src/safety_filter.rs
+++ b/crates/roz-copper/src/safety_filter.rs
@@ -1,4 +1,4 @@
-use roz_core::channels::ChannelManifest;
+use roz_core::channels::{ChannelManifest, InterfaceType};
 use roz_core::command::{CommandFrame, MotorCommand};
 
 /// Copper task that clamps motor commands to safety limits.
@@ -156,18 +156,36 @@ impl SafetyFilterTask {
                     .max_rate_of_change
                     .map_or(v, |max_rate| v.clamp(prev - max_rate, prev + max_rate));
 
-                // 4. Position limit enforcement (if paired with a state channel)
+                // 4. Position limit enforcement (if paired with a state channel).
+                //
+                // The safe action depends on the command interface type:
+                //   - Velocity: zero the command (stop moving toward the limit).
+                //   - Position/Effort: clamp to the boundary (hold at the limit,
+                //     do NOT zero — zero means "go to origin" for position channels).
                 if let Some(pos_idx) = desc.position_state_index
                     && let Some(&pos) = self.current_positions.get(pos_idx)
                     && let Some(pos_desc) = manifest.states.get(pos_idx)
                 {
                     let upper = pos_desc.limits.1;
                     let lower = pos_desc.limits.0;
-                    if pos >= upper - POSITION_LIMIT_MARGIN && v > 0.0 {
-                        return 0.0;
-                    }
-                    if pos <= lower + POSITION_LIMIT_MARGIN && v < 0.0 {
-                        return 0.0;
+
+                    match desc.interface_type {
+                        InterfaceType::Velocity => {
+                            if pos >= upper - POSITION_LIMIT_MARGIN && v > 0.0 {
+                                return 0.0;
+                            }
+                            if pos <= lower + POSITION_LIMIT_MARGIN && v < 0.0 {
+                                return 0.0;
+                            }
+                        }
+                        InterfaceType::Position | InterfaceType::Effort => {
+                            if pos >= upper - POSITION_LIMIT_MARGIN && v > pos {
+                                return v.clamp(lower, upper);
+                            }
+                            if pos <= lower + POSITION_LIMIT_MARGIN && v < pos {
+                                return v.clamp(lower, upper);
+                            }
+                        }
                     }
                 }
 
@@ -430,6 +448,96 @@ mod tests {
         assert_eq!(
             clamped.values[0], 0.0,
             "positive velocity near upper position limit should be zeroed"
+        );
+    }
+
+    #[test]
+    fn clamp_frame_position_channel_clamps_to_limit_not_zero() {
+        // Build a minimal position-controlled manifest (1 command channel)
+        use roz_core::channels::{ChannelDescriptor, InterfaceType};
+
+        let manifest = ChannelManifest {
+            robot_id: "test_pos".into(),
+            robot_class: "test".into(),
+            control_rate_hz: 50,
+            commands: vec![ChannelDescriptor {
+                name: "joint/position".into(),
+                interface_type: InterfaceType::Position,
+                unit: "rad".into(),
+                limits: (-0.698, 0.698), // +/-40 degrees
+                default: 0.0,
+                max_rate_of_change: None,
+                position_state_index: Some(0),
+            }],
+            states: vec![ChannelDescriptor {
+                name: "joint/position".into(),
+                interface_type: InterfaceType::Position,
+                unit: "rad".into(),
+                limits: (-0.698, 0.698),
+                default: 0.0,
+                max_rate_of_change: None,
+                position_state_index: None,
+            }],
+        };
+
+        let mut filter = SafetyFilterTask::new(std::f64::consts::PI, 0.0, None);
+
+        // Position near upper limit
+        filter.update_positions(&[0.68]);
+
+        // Command above the limit
+        let frame = CommandFrame { values: vec![0.75] };
+        let clamped = filter.clamp_frame(&frame, &manifest);
+
+        // Position channel: should clamp to upper limit (0.698), NOT return 0.0
+        assert!(
+            (clamped.values[0] - 0.698).abs() < 0.01,
+            "position channel should clamp to limit 0.698, got {}",
+            clamped.values[0]
+        );
+    }
+
+    #[test]
+    fn clamp_frame_velocity_channel_still_zeros_at_limit() {
+        // Existing velocity behavior must be preserved
+        use roz_core::channels::{ChannelDescriptor, InterfaceType};
+
+        let manifest = ChannelManifest {
+            robot_id: "test_vel".into(),
+            robot_class: "test".into(),
+            control_rate_hz: 100,
+            commands: vec![ChannelDescriptor {
+                name: "joint/velocity".into(),
+                interface_type: InterfaceType::Velocity,
+                unit: "rad/s".into(),
+                limits: (-1.5, 1.5),
+                default: 0.0,
+                max_rate_of_change: None,
+                position_state_index: Some(0),
+            }],
+            states: vec![ChannelDescriptor {
+                name: "joint/position".into(),
+                interface_type: InterfaceType::Position,
+                unit: "rad".into(),
+                limits: (-std::f64::consts::TAU, std::f64::consts::TAU),
+                default: 0.0,
+                max_rate_of_change: None,
+                position_state_index: None,
+            }],
+        };
+
+        let mut filter = SafetyFilterTask::new(1.5, 0.0, None);
+        let near_upper = std::f64::consts::TAU - 0.03;
+        filter.update_positions(&[near_upper]);
+
+        let frame = CommandFrame { values: vec![0.5] };
+        let clamped = filter.clamp_frame(&frame, &manifest);
+
+        // Velocity channel: should still return 0.0 (existing behavior)
+        assert_eq!(
+            clamped.values[0], 0.0,
+            "velocity channel should zero at boundary, got {}",
+            clamped.values[0]
         );
     }
 

--- a/crates/roz-copper/src/safety_filter.rs
+++ b/crates/roz-copper/src/safety_filter.rs
@@ -178,9 +178,9 @@ impl SafetyFilterTask {
 
                 match desc.interface_type {
                     InterfaceType::Velocity => {
-                        if pos >= upper - POSITION_LIMIT_MARGIN && v > 0.0 {
-                            v = 0.0;
-                        } else if pos <= lower + POSITION_LIMIT_MARGIN && v < 0.0 {
+                        if (pos >= upper - POSITION_LIMIT_MARGIN && v > 0.0)
+                            || (pos <= lower + POSITION_LIMIT_MARGIN && v < 0.0)
+                        {
                             v = 0.0;
                         }
                     }
@@ -205,7 +205,7 @@ impl SafetyFilterTask {
                 };
                 let delta = v - other_val;
                 if delta.abs() > max_delta {
-                    v = other_val + delta.signum() * max_delta;
+                    v = delta.signum().mul_add(max_delta, other_val);
                 }
             }
 
@@ -430,10 +430,16 @@ mod tests {
         assert_eq!(clamped.values, vec![0.0, 0.0]);
     }
 
+    fn load_ur5_manifest() -> ChannelManifest {
+        let toml_str = include_str!("../../../examples/ur5/robot.toml");
+        let robot: crate::manifest::RobotManifest = toml::from_str(toml_str).unwrap();
+        robot.channel_manifest().unwrap()
+    }
+
     #[test]
     fn clamp_frame_rate_of_change_limiting() {
         // UR5 manifest has max_rate_of_change = Some(0.5) for velocity commands.
-        let manifest = ChannelManifest::ur5();
+        let manifest = load_ur5_manifest();
         let mut filter = SafetyFilterTask::new(std::f64::consts::PI, 0.0, None);
 
         // Request a large velocity jump from default (0.0).
@@ -451,7 +457,7 @@ mod tests {
 
     #[test]
     fn clamp_frame_position_limit_enforcement() {
-        let manifest = ChannelManifest::ur5();
+        let manifest = load_ur5_manifest();
         let mut filter = SafetyFilterTask::new(std::f64::consts::PI, 0.0, None);
 
         // Inject position near upper limit for joint 0 (state channel 0).

--- a/crates/roz-copper/src/safety_filter.rs
+++ b/crates/roz-copper/src/safety_filter.rs
@@ -143,67 +143,78 @@ impl SafetyFilterTask {
     /// 4. **Position limit enforcement** -- zeroes velocity when the paired position state
     ///    channel is at/beyond its boundary moving toward it.
     pub fn clamp_frame(&mut self, frame: &CommandFrame, manifest: &ChannelManifest) -> CommandFrame {
-        let values: Vec<f64> = frame
-            .values
-            .iter()
-            .enumerate()
-            .map(|(i, &v)| {
-                let Some(desc) = manifest.commands.get(i) else {
-                    return 0.0; // Out-of-bounds channel — safe default
-                };
+        let mut clamped_so_far: Vec<f64> = Vec::with_capacity(frame.values.len());
 
-                // 1. NaN/Inf → channel default
-                let v = if v.is_finite() { v } else { desc.default };
+        for (i, &raw_v) in frame.values.iter().enumerate() {
+            let Some(desc) = manifest.commands.get(i) else {
+                clamped_so_far.push(0.0); // Out-of-bounds channel — safe default
+                continue;
+            };
 
-                // 2. Per-channel limit clamp
-                let v = v.clamp(desc.limits.0, desc.limits.1);
+            // 1. NaN/Inf → channel default
+            let mut v = if raw_v.is_finite() { raw_v } else { desc.default };
 
-                // 3. Rate-of-change limiting (if configured for this channel)
-                let prev = self.prev_velocities.get(i).copied().unwrap_or(desc.default);
-                let v = desc
-                    .max_rate_of_change
-                    .map_or(v, |max_rate| v.clamp(prev - max_rate, prev + max_rate));
+            // 2. Per-channel limit clamp
+            v = v.clamp(desc.limits.0, desc.limits.1);
 
-                // 4. Position limit enforcement (if paired with a state channel).
-                //
-                // The safe action depends on the command interface type:
-                //   - Velocity: zero the command (stop moving toward the limit).
-                //   - Position/Effort: clamp to the boundary (hold at the limit,
-                //     do NOT zero — zero means "go to origin" for position channels).
-                if let Some(pos_idx) = desc.position_state_index
-                    && let Some(&pos) = self.current_positions.get(pos_idx)
-                    && let Some(pos_desc) = manifest.states.get(pos_idx)
-                {
-                    let upper = pos_desc.limits.1;
-                    let lower = pos_desc.limits.0;
+            // 3. Rate-of-change limiting (if configured for this channel)
+            let prev = self.prev_velocities.get(i).copied().unwrap_or(desc.default);
+            v = desc
+                .max_rate_of_change
+                .map_or(v, |max_rate| v.clamp(prev - max_rate, prev + max_rate));
 
-                    match desc.interface_type {
-                        InterfaceType::Velocity => {
-                            if pos >= upper - POSITION_LIMIT_MARGIN && v > 0.0 {
-                                return 0.0;
-                            }
-                            if pos <= lower + POSITION_LIMIT_MARGIN && v < 0.0 {
-                                return 0.0;
-                            }
+            // 4. Position limit enforcement (if paired with a state channel).
+            //
+            // The safe action depends on the command interface type:
+            //   - Velocity: zero the command (stop moving toward the limit).
+            //   - Position/Effort: clamp to the boundary (hold at the limit,
+            //     do NOT zero — zero means "go to origin" for position channels).
+            if let Some(pos_idx) = desc.position_state_index
+                && let Some(&pos) = self.current_positions.get(pos_idx)
+                && let Some(pos_desc) = manifest.states.get(pos_idx)
+            {
+                let upper = pos_desc.limits.1;
+                let lower = pos_desc.limits.0;
+
+                match desc.interface_type {
+                    InterfaceType::Velocity => {
+                        if pos >= upper - POSITION_LIMIT_MARGIN && v > 0.0 {
+                            v = 0.0;
+                        } else if pos <= lower + POSITION_LIMIT_MARGIN && v < 0.0 {
+                            v = 0.0;
                         }
-                        InterfaceType::Position | InterfaceType::Effort => {
-                            if pos >= upper - POSITION_LIMIT_MARGIN && v > pos {
-                                return v.clamp(lower, upper);
-                            }
-                            if pos <= lower + POSITION_LIMIT_MARGIN && v < pos {
-                                return v.clamp(lower, upper);
-                            }
+                    }
+                    InterfaceType::Position | InterfaceType::Effort => {
+                        if (pos >= upper - POSITION_LIMIT_MARGIN && v > pos)
+                            || (pos <= lower + POSITION_LIMIT_MARGIN && v < pos)
+                        {
+                            v = v.clamp(lower, upper);
                         }
                     }
                 }
+            }
 
-                v
-            })
-            .collect();
+            // 5. Cross-channel delta constraint
+            if let Some((other_idx, max_delta)) = desc.max_delta_from {
+                // Use the already-clamped value of the other channel if available,
+                // otherwise use the raw input value.
+                let other_val = if other_idx < clamped_so_far.len() {
+                    clamped_so_far[other_idx]
+                } else {
+                    frame.values.get(other_idx).copied().unwrap_or(0.0)
+                };
+                let delta = v - other_val;
+                if delta.abs() > max_delta {
+                    v = other_val + delta.signum() * max_delta;
+                }
+            }
 
-        self.prev_velocities.clone_from(&values);
+            clamped_so_far.push(v);
+        }
 
-        CommandFrame { values }
+        self.prev_velocities.clone_from(&clamped_so_far);
+
+        CommandFrame { values: clamped_so_far }
     }
 }
 
@@ -591,5 +602,63 @@ mod tests {
         let frame = CommandFrame { values: vec![] };
         let clamped = filter.clamp_frame(&frame, &manifest);
         assert!(clamped.values.is_empty());
+    }
+
+    #[test]
+    fn clamp_frame_enforces_yaw_delta_constraint() {
+        use roz_core::channels::{ChannelDescriptor, InterfaceType};
+
+        let limit_65_deg = 65.0_f64.to_radians();
+        let manifest = ChannelManifest {
+            robot_id: "test".into(),
+            robot_class: "test".into(),
+            control_rate_hz: 50,
+            commands: vec![
+                ChannelDescriptor {
+                    name: "head_yaw".into(),
+                    interface_type: InterfaceType::Position,
+                    unit: "rad".into(),
+                    limits: (-std::f64::consts::PI, std::f64::consts::PI),
+                    default: 0.0,
+                    max_rate_of_change: None,
+                    position_state_index: None,
+                    max_delta_from: Some((1, limit_65_deg)), // constrained to body_yaw
+                },
+                ChannelDescriptor {
+                    name: "body_yaw".into(),
+                    interface_type: InterfaceType::Position,
+                    unit: "rad".into(),
+                    limits: (-std::f64::consts::PI, std::f64::consts::PI),
+                    default: 0.0,
+                    max_rate_of_change: None,
+                    position_state_index: None,
+                    max_delta_from: None,
+                },
+            ],
+            states: vec![],
+        };
+
+        let mut filter = SafetyFilterTask::new(std::f64::consts::PI, 0.0, None);
+
+        // Body at 0, head at 90 deg (exceeds 65 deg delta) -> clamp to 65 deg
+        let frame = CommandFrame {
+            values: vec![std::f64::consts::FRAC_PI_2, 0.0],
+        };
+        let clamped = filter.clamp_frame(&frame, &manifest);
+        assert!(
+            (clamped.values[0] - limit_65_deg).abs() < 0.01,
+            "head yaw should clamp to 65 deg from body, got {} deg",
+            clamped.values[0].to_degrees()
+        );
+
+        // Body at 0, head at 50 deg (within 65 deg) -> pass through
+        let frame2 = CommandFrame {
+            values: vec![50.0_f64.to_radians(), 0.0],
+        };
+        let clamped2 = filter.clamp_frame(&frame2, &manifest);
+        assert!(
+            (clamped2.values[0] - 50.0_f64.to_radians()).abs() < 0.01,
+            "head yaw within delta should pass through"
+        );
     }
 }

--- a/crates/roz-copper/src/state_injector.rs
+++ b/crates/roz-copper/src/state_injector.rs
@@ -1,0 +1,74 @@
+//! Trait for injecting sensor data into the WASM controller's HostContext.
+//!
+//! Implementations bridge hardware-specific sensor APIs to the generic
+//! channel-based state interface. The controller loop calls `inject()`
+//! before each WASM tick.
+
+use crate::wit_host::HostContext;
+
+/// Source of sensor data for the controller loop.
+///
+/// Implementations read from hardware (or simulation) and write into
+/// the `HostContext`'s `state_values` array. Called once per tick
+/// before the WASM controller runs.
+pub trait StateInjector: Send {
+    /// Inject the latest sensor readings into the host context.
+    ///
+    /// Implementors should:
+    /// 1. Read the latest sensor data (non-blocking).
+    /// 2. Write values into `ctx.state_values` by channel index.
+    /// 3. Optionally update `ctx.sim_time_ns` for timing.
+    fn inject(&mut self, ctx: &mut HostContext);
+}
+
+/// No-op injector for controllers that don't need sensor input.
+pub struct NullStateInjector;
+
+impl StateInjector for NullStateInjector {
+    fn inject(&mut self, _ctx: &mut HostContext) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use roz_core::channels::ChannelManifest;
+
+    struct FakeInjector {
+        values: Vec<f64>,
+    }
+
+    impl StateInjector for FakeInjector {
+        fn inject(&mut self, ctx: &mut HostContext) {
+            for (i, &v) in self.values.iter().enumerate() {
+                if i < ctx.state_values.len() {
+                    ctx.state_values[i] = v;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn fake_injector_writes_state_values() {
+        let manifest = ChannelManifest::reachy_mini();
+        let mut ctx = HostContext::with_manifest(manifest);
+        assert!(ctx.state_values.iter().all(|&v| v == 0.0));
+
+        let mut injector = FakeInjector {
+            values: vec![0.01, 0.02, 0.0, 0.1, 0.2, 0.5, 0.3, 0.8, 0.8],
+        };
+        injector.inject(&mut ctx);
+
+        assert!((ctx.state_values[0] - 0.01).abs() < f64::EPSILON);
+        assert!((ctx.state_values[5] - 0.5).abs() < f64::EPSILON);
+        assert!((ctx.state_values[8] - 0.8).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn null_injector_is_noop() {
+        let manifest = ChannelManifest::reachy_mini();
+        let mut ctx = HostContext::with_manifest(manifest);
+        let mut injector = NullStateInjector;
+        injector.inject(&mut ctx);
+        assert!(ctx.state_values.iter().all(|&v| v == 0.0));
+    }
+}

--- a/crates/roz-copper/src/state_injector.rs
+++ b/crates/roz-copper/src/state_injector.rs
@@ -1,4 +1,4 @@
-//! Trait for injecting sensor data into the WASM controller's HostContext.
+//! Trait for injecting sensor data into the WASM controller's `HostContext`.
 //!
 //! Implementations bridge hardware-specific sensor APIs to the generic
 //! channel-based state interface. The controller loop calls `inject()`
@@ -47,9 +47,15 @@ mod tests {
         }
     }
 
+    fn load_reachy_mini_manifest() -> ChannelManifest {
+        let toml_str = include_str!("../../../examples/reachy-mini/robot.toml");
+        let robot: crate::manifest::RobotManifest = toml::from_str(toml_str).unwrap();
+        robot.channel_manifest().unwrap()
+    }
+
     #[test]
     fn fake_injector_writes_state_values() {
-        let manifest = ChannelManifest::reachy_mini();
+        let manifest = load_reachy_mini_manifest();
         let mut ctx = HostContext::with_manifest(manifest);
         assert!(ctx.state_values.iter().all(|&v| v == 0.0));
 
@@ -65,7 +71,7 @@ mod tests {
 
     #[test]
     fn null_injector_is_noop() {
-        let manifest = ChannelManifest::reachy_mini();
+        let manifest = load_reachy_mini_manifest();
         let mut ctx = HostContext::with_manifest(manifest);
         let mut injector = NullStateInjector;
         injector.inject(&mut ctx);

--- a/crates/roz-copper/src/wasm.rs
+++ b/crates/roz-copper/src/wasm.rs
@@ -370,6 +370,26 @@ mod tests {
     }
 
     #[test]
+    fn wasm_reads_config_via_host_functions() {
+        // WAT module that calls config::get_len and stores result in a global
+        let wat = r#"
+            (module
+                (import "config" "get_len" (func $config_len (result i32)))
+                (global $len (export "config_len") (mut i32) (i32.const -1))
+                (func (export "process") (param i64)
+                    (global.set $len (call $config_len))
+                )
+            )
+        "#;
+        let mut host = HostContext::default();
+        host.config_json = br#"{"kp":1.5}"#.to_vec();
+        let mut task = CuWasmTask::from_source_with_host(wat.as_bytes(), host).unwrap();
+        task.tick(0).unwrap();
+        let len = task.get_global_i32("config_len").unwrap();
+        assert_eq!(len, 10); // {"kp":1.5} is 10 bytes
+    }
+
+    #[test]
     fn wasm_long_computation_interrupted_within_budget() {
         // WAT module with a loop that takes ~50ms
         // At deadline 8 (8ms), should be interrupted well before completion

--- a/crates/roz-copper/src/wit_host.rs
+++ b/crates/roz-copper/src/wit_host.rs
@@ -74,6 +74,10 @@ pub struct HostContext {
     /// Count of WIT host function rejections (velocity exceeded, NaN, etc.).
     /// Incremented by host functions, checked by verification.
     pub rejection_count: AtomicU32,
+    /// Agent-writable JSON config, readable by WASM via `config::get_len`
+    /// and `config::get_copy` host functions. Updated between ticks via
+    /// `ControllerCommand::UpdateParams`.
+    pub config_json: Vec<u8>,
 }
 
 impl Default for HostContext {
@@ -95,6 +99,7 @@ impl Default for HostContext {
                 .build(),
             sim_time_ns: 0,
             rejection_count: AtomicU32::new(0),
+            config_json: Vec::new(),
         }
     }
 }
@@ -209,6 +214,7 @@ pub fn register_host_functions(linker: &mut Linker<HostContext>) -> anyhow::Resu
     register_channel_functions(linker)?;
     register_legacy_functions(linker)?;
     register_system_functions(linker)?;
+    register_config_functions(linker)?;
     Ok(())
 }
 
@@ -503,6 +509,42 @@ fn register_system_functions(linker: &mut Linker<HostContext>) -> anyhow::Result
     Ok(())
 }
 
+/// Register config host functions: `config::get_len` and `config::get_copy`.
+///
+/// These allow WASM controllers to read agent-provided JSON config
+/// (e.g., PID gains) that was injected via `ControllerCommand::UpdateParams`.
+fn register_config_functions(linker: &mut Linker<HostContext>) -> anyhow::Result<()> {
+    // config::get_len — WASM queries config size
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    linker.func_wrap(
+        "config",
+        "get_len",
+        |caller: wasmtime::Caller<'_, HostContext>| -> i32 { caller.data().config_json.len() as i32 },
+    )?;
+
+    // config::get_copy — WASM provides buffer, host copies config into it
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+    linker.func_wrap(
+        "config",
+        "get_copy",
+        |mut caller: wasmtime::Caller<'_, HostContext>, ptr: i32, max_len: i32| -> i32 {
+            let config = caller.data().config_json.clone(); // clone to avoid borrow conflict
+            let copy_len = config.len().min(max_len as usize);
+            if copy_len == 0 {
+                return 0;
+            }
+            if let Some(memory) = caller.get_export("memory").and_then(|e| e.into_memory()) {
+                if memory.write(&mut caller, ptr as usize, &config[..copy_len]).is_ok() {
+                    return copy_len as i32;
+                }
+            }
+            0 // write failed
+        },
+    )?;
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -549,6 +591,7 @@ mod tests {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "joint1/velocity".into(),
@@ -558,6 +601,7 @@ mod tests {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
             ],
             states: vec![
@@ -569,6 +613,7 @@ mod tests {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "joint1/position".into(),
@@ -578,6 +623,7 @@ mod tests {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
             ],
         }
@@ -1301,6 +1347,7 @@ mod tests {
                 default: 0.0,
                 max_rate_of_change: None,
                 position_state_index: None,
+                max_delta_from: None,
             }],
             states: vec![
                 ChannelDescriptor {
@@ -1311,6 +1358,7 @@ mod tests {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "j0/velocity".into(),
@@ -1320,6 +1368,7 @@ mod tests {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
             ],
         };
@@ -1374,6 +1423,19 @@ mod tests {
             other => panic!("expected i32, got {other:?}"),
         };
         assert_eq!(cnt, 6, "get_joint_count should return 6 for UR5");
+    }
+
+    #[test]
+    fn config_json_starts_empty() {
+        let ctx = HostContext::default();
+        assert!(ctx.config_json.is_empty());
+    }
+
+    #[test]
+    fn config_json_with_manifest_starts_empty() {
+        let manifest = roz_core::channels::ChannelManifest::default();
+        let ctx = HostContext::with_manifest(manifest);
+        assert!(ctx.config_json.is_empty());
     }
 
     #[test]

--- a/crates/roz-copper/src/wit_host.rs
+++ b/crates/roz-copper/src/wit_host.rs
@@ -533,10 +533,10 @@ fn register_config_functions(linker: &mut Linker<HostContext>) -> anyhow::Result
             if copy_len == 0 {
                 return 0;
             }
-            if let Some(memory) = caller.get_export("memory").and_then(|e| e.into_memory()) {
-                if memory.write(&mut caller, ptr as usize, &config[..copy_len]).is_ok() {
-                    return copy_len as i32;
-                }
+            if let Some(memory) = caller.get_export("memory").and_then(wasmtime::Extern::into_memory)
+                && memory.write(&mut caller, ptr as usize, &config[..copy_len]).is_ok()
+            {
+                return copy_len as i32;
             }
             0 // write failed
         },
@@ -1410,8 +1410,8 @@ mod tests {
                 )
             )
         "#;
-        // Use UR5 manifest (6 commands) to test backward-compat joint count.
-        let host = HostContext::with_manifest(ChannelManifest::ur5());
+        // Use generic_velocity(6, PI) to test backward-compat joint count.
+        let host = HostContext::with_manifest(ChannelManifest::generic_velocity(6, std::f64::consts::PI));
         let (_engine, mut store, instance) = instantiate_with_host(wat, host).unwrap();
 
         let process = instance.get_typed_func::<u64, ()>(&mut store, "process").unwrap();

--- a/crates/roz-copper/tests/drone_wasm_velocity.rs
+++ b/crates/roz-copper/tests/drone_wasm_velocity.rs
@@ -31,6 +31,12 @@ use roz_copper::io_grpc::{GrpcActuatorSink, GrpcSensorSource};
 use roz_copper::io_log::{LogActuatorSink, TeeActuatorSink};
 use roz_core::channels::ChannelManifest;
 
+fn load_quadcopter_manifest() -> ChannelManifest {
+    let toml_str = include_str!("../../../examples/quadcopter/robot.toml");
+    let robot: roz_copper::manifest::RobotManifest = toml::from_str(toml_str).unwrap();
+    robot.channel_manifest().unwrap()
+}
+
 const BRIDGE_URL: &str = "http://127.0.0.1:9090";
 
 /// WAT that sets command channel 2 (body/velocity.z) to 0.5 m/s on every tick.
@@ -83,7 +89,7 @@ async fn drone_wasm_velocity_through_bridge() {
         }
     };
 
-    let manifest = ChannelManifest::quadcopter();
+    let manifest = load_quadcopter_manifest();
     let grpc_channel = tonic::transport::Channel::from_shared(BRIDGE_URL.to_string())
         .expect("valid URI")
         .connect()
@@ -148,7 +154,7 @@ async fn drone_wasm_velocity_through_bridge() {
     // Load WASM — starts producing velocity commands at 100Hz.
     tx.send(ControllerCommand::LoadWasm(
         DRONE_VZ_WAT.as_bytes().to_vec(),
-        ChannelManifest::quadcopter(),
+        load_quadcopter_manifest(),
     ))
     .expect("send LoadWasm");
 

--- a/crates/roz-copper/tests/drone_wasm_velocity.rs
+++ b/crates/roz-copper/tests/drone_wasm_velocity.rs
@@ -106,6 +106,7 @@ async fn drone_wasm_velocity_through_bridge() {
     let (_emergency_tx, emergency_rx) = std::sync::mpsc::sync_channel(1);
     let state = Arc::new(ArcSwap::from_pointee(roz_copper::channels::ControllerState::default()));
     let shutdown = Arc::new(AtomicBool::new(false));
+    let (estop_tx, _estop_rx) = tokio::sync::mpsc::channel::<String>(4);
 
     let s = Arc::clone(&state);
     let sd = Arc::clone(&shutdown);
@@ -120,6 +121,7 @@ async fn drone_wasm_velocity_through_bridge() {
             Some(&mut sensor_owned),
             Duration::from_secs(60),
             Some(&emergency_rx),
+            &estop_tx,
         );
     });
 

--- a/crates/roz-copper/tests/e2e_wasm_actuator_bridge.rs
+++ b/crates/roz-copper/tests/e2e_wasm_actuator_bridge.rs
@@ -55,6 +55,7 @@ async fn wasm_velocity_reaches_gazebo_via_grpc() {
     let (_emergency_tx, emergency_rx) = std::sync::mpsc::sync_channel(1);
     let state = Arc::new(ArcSwap::from_pointee(ControllerState::default()));
     let shutdown = Arc::new(AtomicBool::new(false));
+    let (estop_tx, _estop_rx) = tokio::sync::mpsc::channel::<String>(4);
 
     let s = Arc::clone(&state);
     let sd = Arc::clone(&shutdown);
@@ -69,6 +70,7 @@ async fn wasm_velocity_reaches_gazebo_via_grpc() {
             None, // no sensor for this test
             Duration::from_secs(60),
             Some(&emergency_rx),
+            &estop_tx,
         );
     });
 

--- a/crates/roz-copper/tests/e2e_wasm_to_gazebo.rs
+++ b/crates/roz-copper/tests/e2e_wasm_to_gazebo.rs
@@ -62,6 +62,7 @@ async fn wasm_controller_with_live_gazebo_sensor() {
     let (_emergency_tx, emergency_rx) = std::sync::mpsc::sync_channel(1);
     let state = Arc::new(ArcSwap::from_pointee(ControllerState::default()));
     let shutdown = Arc::new(AtomicBool::new(false));
+    let (estop_tx, _estop_rx) = tokio::sync::mpsc::channel::<String>(4);
 
     let s = Arc::clone(&state);
     let sd = Arc::clone(&shutdown);
@@ -77,6 +78,7 @@ async fn wasm_controller_with_live_gazebo_sensor() {
             Some(&mut sensor),
             Duration::from_secs(60),
             Some(&emergency_rx),
+            &estop_tx,
         );
     });
 

--- a/crates/roz-core/src/channels.rs
+++ b/crates/roz-core/src/channels.rs
@@ -297,6 +297,109 @@ impl ChannelManifest {
             .count()
     }
 
+    /// Reachy Mini (Pollen Robotics): 9 position command channels, 9 position state channels.
+    ///
+    /// Cartesian head pose (x,y,z,roll,pitch,yaw) + body yaw + 2 antennas.
+    /// Position-controlled at 50 Hz via the daemon's `set_target()` API.
+    /// Joint limits from official Pollen Robotics documentation.
+    pub fn reachy_mini() -> Self {
+        let limit_40_deg = 40.0_f64.to_radians();
+        let limit_160_deg = 160.0_f64.to_radians();
+
+        let head_pos_names = ["head/position.x", "head/position.y", "head/position.z"];
+        let head_pos_limits = [
+            (-0.03, 0.03),   // x: ±30mm
+            (-0.03, 0.03),   // y: ±30mm
+            (-0.015, 0.015), // z: ±15mm
+        ];
+
+        let head_orient_names = [
+            "head/orientation.roll",
+            "head/orientation.pitch",
+            "head/orientation.yaw",
+        ];
+        let head_orient_limits = [
+            (-limit_40_deg, limit_40_deg), // roll: ±40 deg
+            (-limit_40_deg, limit_40_deg), // pitch: ±40 deg
+            (-PI, PI),                     // yaw: ±180 deg
+        ];
+
+        let mut commands = Vec::with_capacity(9);
+
+        for (name, limits) in head_pos_names.iter().zip(head_pos_limits.iter()) {
+            let idx = commands.len();
+            commands.push(ChannelDescriptor {
+                name: (*name).into(),
+                interface_type: InterfaceType::Position,
+                unit: "m".into(),
+                limits: *limits,
+                default: 0.0,
+                max_rate_of_change: None,
+                position_state_index: Some(idx),
+            });
+        }
+
+        for (name, limits) in head_orient_names.iter().zip(head_orient_limits.iter()) {
+            let idx = commands.len();
+            commands.push(ChannelDescriptor {
+                name: (*name).into(),
+                interface_type: InterfaceType::Position,
+                unit: "rad".into(),
+                limits: *limits,
+                default: 0.0,
+                max_rate_of_change: None,
+                position_state_index: Some(idx),
+            });
+        }
+
+        // Body yaw (index 6)
+        commands.push(ChannelDescriptor {
+            name: "body/yaw".into(),
+            interface_type: InterfaceType::Position,
+            unit: "rad".into(),
+            limits: (-limit_160_deg, limit_160_deg),
+            default: 0.0,
+            max_rate_of_change: None,
+            position_state_index: Some(6),
+        });
+
+        // Antennas (indices 7-8)
+        for name in ["left_antenna/position", "right_antenna/position"] {
+            let idx = commands.len();
+            commands.push(ChannelDescriptor {
+                name: name.into(),
+                interface_type: InterfaceType::Position,
+                unit: "rad".into(),
+                limits: (0.0, 120.0_f64.to_radians()),
+                default: 0.0,
+                max_rate_of_change: None,
+                position_state_index: Some(idx),
+            });
+        }
+
+        // State channels mirror commands
+        let states: Vec<ChannelDescriptor> = commands
+            .iter()
+            .map(|cmd| ChannelDescriptor {
+                name: cmd.name.clone(),
+                interface_type: cmd.interface_type,
+                unit: cmd.unit.clone(),
+                limits: cmd.limits,
+                default: cmd.default,
+                max_rate_of_change: None,
+                position_state_index: None,
+            })
+            .collect();
+
+        Self {
+            robot_id: "reachy_mini".into(),
+            robot_class: "expressive".into(),
+            control_rate_hz: 50,
+            commands,
+            states,
+        }
+    }
+
     /// Generic N-joint velocity-only manifest for backward compatibility.
     ///
     /// Creates `n_joints` velocity command channels with symmetric limits
@@ -447,5 +550,37 @@ mod tests {
 
         assert_eq!(m.commands[0].name, "base/linear.x");
         assert_eq!(m.commands[1].name, "base/angular.z");
+    }
+
+    #[test]
+    fn reachy_mini_manifest_structure() {
+        let m = ChannelManifest::reachy_mini();
+        assert_eq!(m.robot_id, "reachy_mini");
+        assert_eq!(m.robot_class, "expressive");
+        assert_eq!(m.control_rate_hz, 50);
+        assert_eq!(m.commands.len(), 9);
+        assert_eq!(m.states.len(), 9);
+
+        assert_eq!(m.commands[0].name, "head/position.x");
+        assert_eq!(m.commands[5].name, "head/orientation.yaw");
+        assert_eq!(m.commands[6].name, "body/yaw");
+        assert_eq!(m.commands[7].name, "left_antenna/position");
+        assert_eq!(m.commands[8].name, "right_antenna/position");
+
+        // All position type
+        assert!(m.commands.iter().all(|c| c.interface_type == InterfaceType::Position));
+
+        // Head pitch ±40 deg
+        let limit_40 = 40.0_f64.to_radians();
+        assert!((m.commands[4].limits.1 - limit_40).abs() < 0.001);
+
+        // Body yaw ±160 deg
+        let limit_160 = 160.0_f64.to_radians();
+        assert!((m.commands[6].limits.1 - limit_160).abs() < 0.001);
+
+        // State/command pairing
+        for (i, cmd) in m.commands.iter().enumerate() {
+            assert_eq!(cmd.position_state_index, Some(i));
+        }
     }
 }

--- a/crates/roz-core/src/channels.rs
+++ b/crates/roz-core/src/channels.rs
@@ -51,6 +51,11 @@ pub struct ChannelDescriptor {
     /// `None` = no position limit checking for this channel.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub position_state_index: Option<usize>,
+    /// Maximum absolute delta between this channel and another command channel.
+    /// Used for coupled constraints (e.g., head-body yaw cable limit).
+    /// Format: `(other_command_index, max_delta_radians)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_delta_from: Option<(usize, f64)>,
 }
 
 // ---------------------------------------------------------------------------
@@ -97,6 +102,7 @@ impl ChannelManifest {
                 default: 0.0,
                 max_rate_of_change: Some(0.5), // 50 rad/s^2 at 100 Hz
                 position_state_index: Some(i), // pairs with position state at same index
+                max_delta_from: None,
             })
             .collect();
 
@@ -111,6 +117,7 @@ impl ChannelManifest {
                 default: 0.0,
                 max_rate_of_change: None,
                 position_state_index: None,
+                max_delta_from: None,
             })
             .collect();
 
@@ -122,6 +129,7 @@ impl ChannelManifest {
             default: 0.0,
             max_rate_of_change: None,
             position_state_index: None,
+            max_delta_from: None,
         }));
 
         Self {
@@ -148,6 +156,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: Some(2.0),
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "body/velocity.y".into(),
@@ -157,6 +166,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: Some(2.0),
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "body/velocity.z".into(),
@@ -166,6 +176,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: Some(1.5),
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "body/yaw_rate".into(),
@@ -175,6 +186,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: Some(1.0),
                     position_state_index: None,
+                    max_delta_from: None,
                 },
             ],
             states: vec![
@@ -186,6 +198,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "body/position.y".into(),
@@ -195,6 +208,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "body/position.z".into(),
@@ -204,6 +218,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "body/yaw".into(),
@@ -213,6 +228,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
             ],
         }
@@ -233,6 +249,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: Some(0.5),
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "base/angular.z".into(),
@@ -242,6 +259,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: Some(1.0),
                     position_state_index: None,
+                    max_delta_from: None,
                 },
             ],
             states: vec![
@@ -253,6 +271,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "base/odom.y".into(),
@@ -262,6 +281,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "base/odom.yaw".into(),
@@ -271,6 +291,7 @@ impl ChannelManifest {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
             ],
         }
@@ -336,6 +357,7 @@ impl ChannelManifest {
                 default: 0.0,
                 max_rate_of_change: None,
                 position_state_index: Some(idx),
+                max_delta_from: None,
             });
         }
 
@@ -349,6 +371,7 @@ impl ChannelManifest {
                 default: 0.0,
                 max_rate_of_change: None,
                 position_state_index: Some(idx),
+                max_delta_from: None,
             });
         }
 
@@ -361,6 +384,7 @@ impl ChannelManifest {
             default: 0.0,
             max_rate_of_change: None,
             position_state_index: Some(6),
+            max_delta_from: None,
         });
 
         // Antennas (indices 7-8)
@@ -374,8 +398,12 @@ impl ChannelManifest {
                 default: 0.0,
                 max_rate_of_change: None,
                 position_state_index: Some(idx),
+                max_delta_from: None,
             });
         }
+
+        // Head yaw (index 5) constrained to <=65 deg from body yaw (index 6)
+        commands[5].max_delta_from = Some((6, 65.0_f64.to_radians()));
 
         // State channels mirror commands
         let states: Vec<ChannelDescriptor> = commands
@@ -388,6 +416,7 @@ impl ChannelManifest {
                 default: cmd.default,
                 max_rate_of_change: None,
                 position_state_index: None,
+                max_delta_from: None,
             })
             .collect();
 
@@ -415,6 +444,7 @@ impl ChannelManifest {
                 default: 0.0,
                 max_rate_of_change: None,
                 position_state_index: None,
+                max_delta_from: None,
             })
             .collect();
 

--- a/crates/roz-core/src/channels.rs
+++ b/crates/roz-core/src/channels.rs
@@ -5,8 +5,6 @@
 //! channels. The WASM controller reads/writes by index; the safety filter
 //! clamps per-channel; the actuator sink routes to the native protocol.
 
-use std::f64::consts::{PI, TAU};
-
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -78,225 +76,6 @@ pub struct ChannelManifest {
 }
 
 impl ChannelManifest {
-    /// UR5 arm: 6 velocity command channels, 12 state channels (6 position + 6 velocity).
-    pub fn ur5() -> Self {
-        let joint_names = [
-            "shoulder_pan_joint",
-            "shoulder_lift_joint",
-            "elbow_joint",
-            "wrist_1_joint",
-            "wrist_2_joint",
-            "wrist_3_joint",
-        ];
-        let vel_limit = PI; // rad/s
-        let pos_limit = TAU; // rad
-
-        let commands: Vec<ChannelDescriptor> = joint_names
-            .iter()
-            .enumerate()
-            .map(|(i, name)| ChannelDescriptor {
-                name: format!("{name}/velocity"),
-                interface_type: InterfaceType::Velocity,
-                unit: "rad/s".into(),
-                limits: (-vel_limit, vel_limit),
-                default: 0.0,
-                max_rate_of_change: Some(0.5), // 50 rad/s^2 at 100 Hz
-                position_state_index: Some(i), // pairs with position state at same index
-                max_delta_from: None,
-            })
-            .collect();
-
-        // Position state channels first (indices 0-5), then velocity states (indices 6-11).
-        let mut states: Vec<ChannelDescriptor> = joint_names
-            .iter()
-            .map(|name| ChannelDescriptor {
-                name: format!("{name}/position"),
-                interface_type: InterfaceType::Position,
-                unit: "rad".into(),
-                limits: (-pos_limit, pos_limit),
-                default: 0.0,
-                max_rate_of_change: None,
-                position_state_index: None,
-                max_delta_from: None,
-            })
-            .collect();
-
-        states.extend(joint_names.iter().map(|name| ChannelDescriptor {
-            name: format!("{name}/velocity"),
-            interface_type: InterfaceType::Velocity,
-            unit: "rad/s".into(),
-            limits: (-vel_limit, vel_limit),
-            default: 0.0,
-            max_rate_of_change: None,
-            position_state_index: None,
-            max_delta_from: None,
-        }));
-
-        Self {
-            robot_id: "ur5".into(),
-            robot_class: "manipulator".into(),
-            control_rate_hz: 100,
-            commands,
-            states,
-        }
-    }
-
-    /// Quadcopter: 4 body velocity command channels (vx, vy, vz, `yaw_rate`), 4 body state channels.
-    pub fn quadcopter() -> Self {
-        Self {
-            robot_id: "quadcopter".into(),
-            robot_class: "drone".into(),
-            control_rate_hz: 100,
-            commands: vec![
-                ChannelDescriptor {
-                    name: "body/velocity.x".into(),
-                    interface_type: InterfaceType::Velocity,
-                    unit: "m/s".into(),
-                    limits: (-5.0, 5.0),
-                    default: 0.0,
-                    max_rate_of_change: Some(2.0),
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-                ChannelDescriptor {
-                    name: "body/velocity.y".into(),
-                    interface_type: InterfaceType::Velocity,
-                    unit: "m/s".into(),
-                    limits: (-5.0, 5.0),
-                    default: 0.0,
-                    max_rate_of_change: Some(2.0),
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-                ChannelDescriptor {
-                    name: "body/velocity.z".into(),
-                    interface_type: InterfaceType::Velocity,
-                    unit: "m/s".into(),
-                    limits: (-3.0, 3.0),
-                    default: 0.0,
-                    max_rate_of_change: Some(1.5),
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-                ChannelDescriptor {
-                    name: "body/yaw_rate".into(),
-                    interface_type: InterfaceType::Velocity,
-                    unit: "rad/s".into(),
-                    limits: (-std::f64::consts::FRAC_PI_2, std::f64::consts::FRAC_PI_2),
-                    default: 0.0,
-                    max_rate_of_change: Some(1.0),
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-            ],
-            states: vec![
-                ChannelDescriptor {
-                    name: "body/position.x".into(),
-                    interface_type: InterfaceType::Position,
-                    unit: "m".into(),
-                    limits: (-1000.0, 1000.0),
-                    default: 0.0,
-                    max_rate_of_change: None,
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-                ChannelDescriptor {
-                    name: "body/position.y".into(),
-                    interface_type: InterfaceType::Position,
-                    unit: "m".into(),
-                    limits: (-1000.0, 1000.0),
-                    default: 0.0,
-                    max_rate_of_change: None,
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-                ChannelDescriptor {
-                    name: "body/position.z".into(),
-                    interface_type: InterfaceType::Position,
-                    unit: "m".into(),
-                    limits: (0.0, 500.0),
-                    default: 0.0,
-                    max_rate_of_change: None,
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-                ChannelDescriptor {
-                    name: "body/yaw".into(),
-                    interface_type: InterfaceType::Position,
-                    unit: "rad".into(),
-                    limits: (-PI, PI),
-                    default: 0.0,
-                    max_rate_of_change: None,
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-            ],
-        }
-    }
-
-    /// Differential drive: 2 twist command channels (linear.x, angular.z), 3 odometry state channels.
-    pub fn diff_drive() -> Self {
-        Self {
-            robot_id: "diff_drive".into(),
-            robot_class: "mobile".into(),
-            control_rate_hz: 100,
-            commands: vec![
-                ChannelDescriptor {
-                    name: "base/linear.x".into(),
-                    interface_type: InterfaceType::Velocity,
-                    unit: "m/s".into(),
-                    limits: (-1.0, 1.0),
-                    default: 0.0,
-                    max_rate_of_change: Some(0.5),
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-                ChannelDescriptor {
-                    name: "base/angular.z".into(),
-                    interface_type: InterfaceType::Velocity,
-                    unit: "rad/s".into(),
-                    limits: (-2.0, 2.0),
-                    default: 0.0,
-                    max_rate_of_change: Some(1.0),
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-            ],
-            states: vec![
-                ChannelDescriptor {
-                    name: "base/odom.x".into(),
-                    interface_type: InterfaceType::Position,
-                    unit: "m".into(),
-                    limits: (-1000.0, 1000.0),
-                    default: 0.0,
-                    max_rate_of_change: None,
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-                ChannelDescriptor {
-                    name: "base/odom.y".into(),
-                    interface_type: InterfaceType::Position,
-                    unit: "m".into(),
-                    limits: (-1000.0, 1000.0),
-                    default: 0.0,
-                    max_rate_of_change: None,
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-                ChannelDescriptor {
-                    name: "base/odom.yaw".into(),
-                    interface_type: InterfaceType::Position,
-                    unit: "rad".into(),
-                    limits: (-PI, PI),
-                    default: 0.0,
-                    max_rate_of_change: None,
-                    position_state_index: None,
-                    max_delta_from: None,
-                },
-            ],
-        }
-    }
-
     /// Number of command channels.
     pub const fn command_count(&self) -> usize {
         self.commands.len()
@@ -316,117 +95,6 @@ impl ChannelManifest {
             .iter()
             .filter(|s| s.interface_type == InterfaceType::Position)
             .count()
-    }
-
-    /// Reachy Mini (Pollen Robotics): 9 position command channels, 9 position state channels.
-    ///
-    /// Cartesian head pose (x,y,z,roll,pitch,yaw) + body yaw + 2 antennas.
-    /// Position-controlled at 50 Hz via the daemon's `set_target()` API.
-    /// Joint limits from official Pollen Robotics documentation.
-    pub fn reachy_mini() -> Self {
-        let limit_40_deg = 40.0_f64.to_radians();
-        let limit_160_deg = 160.0_f64.to_radians();
-
-        let head_pos_names = ["head/position.x", "head/position.y", "head/position.z"];
-        let head_pos_limits = [
-            (-0.03, 0.03),   // x: ±30mm
-            (-0.03, 0.03),   // y: ±30mm
-            (-0.015, 0.015), // z: ±15mm
-        ];
-
-        let head_orient_names = [
-            "head/orientation.roll",
-            "head/orientation.pitch",
-            "head/orientation.yaw",
-        ];
-        let head_orient_limits = [
-            (-limit_40_deg, limit_40_deg), // roll: ±40 deg
-            (-limit_40_deg, limit_40_deg), // pitch: ±40 deg
-            (-PI, PI),                     // yaw: ±180 deg
-        ];
-
-        let mut commands = Vec::with_capacity(9);
-
-        for (name, limits) in head_pos_names.iter().zip(head_pos_limits.iter()) {
-            let idx = commands.len();
-            commands.push(ChannelDescriptor {
-                name: (*name).into(),
-                interface_type: InterfaceType::Position,
-                unit: "m".into(),
-                limits: *limits,
-                default: 0.0,
-                max_rate_of_change: None,
-                position_state_index: Some(idx),
-                max_delta_from: None,
-            });
-        }
-
-        for (name, limits) in head_orient_names.iter().zip(head_orient_limits.iter()) {
-            let idx = commands.len();
-            commands.push(ChannelDescriptor {
-                name: (*name).into(),
-                interface_type: InterfaceType::Position,
-                unit: "rad".into(),
-                limits: *limits,
-                default: 0.0,
-                max_rate_of_change: None,
-                position_state_index: Some(idx),
-                max_delta_from: None,
-            });
-        }
-
-        // Body yaw (index 6)
-        commands.push(ChannelDescriptor {
-            name: "body/yaw".into(),
-            interface_type: InterfaceType::Position,
-            unit: "rad".into(),
-            limits: (-limit_160_deg, limit_160_deg),
-            default: 0.0,
-            max_rate_of_change: None,
-            position_state_index: Some(6),
-            max_delta_from: None,
-        });
-
-        // Antennas (indices 7-8)
-        for name in ["left_antenna/position", "right_antenna/position"] {
-            let idx = commands.len();
-            commands.push(ChannelDescriptor {
-                name: name.into(),
-                interface_type: InterfaceType::Position,
-                unit: "rad".into(),
-                limits: (0.0, 120.0_f64.to_radians()),
-                default: 0.0,
-                max_rate_of_change: None,
-                position_state_index: Some(idx),
-                max_delta_from: None,
-            });
-        }
-
-        // Head yaw (index 5) constrained to <=65 deg from body yaw (index 6)
-        commands[5].max_delta_from = Some((6, 65.0_f64.to_radians()));
-
-        // State channels mirror commands
-        let states: Vec<ChannelDescriptor> = commands
-            .iter()
-            .map(|cmd| ChannelDescriptor {
-                name: cmd.name.clone(),
-                interface_type: cmd.interface_type,
-                unit: cmd.unit.clone(),
-                limits: cmd.limits,
-                default: cmd.default,
-                max_rate_of_change: None,
-                position_state_index: None,
-                max_delta_from: None,
-            })
-            .collect();
-
-        Self {
-            robot_id: "reachy_mini".into(),
-            robot_class: "expressive".into(),
-            control_rate_hz: 50,
-            commands,
-            states,
-        }
     }
 
     /// Generic N-joint velocity-only manifest for backward compatibility.
@@ -478,11 +146,13 @@ impl Default for ChannelManifest {
 
 #[cfg(test)]
 mod tests {
+    use std::f64::consts::PI;
+
     use super::*;
 
     #[test]
     fn manifest_serde_roundtrip() {
-        let manifest = ChannelManifest::ur5();
+        let manifest = ChannelManifest::generic_velocity(6, PI);
         let json = serde_json::to_string(&manifest).expect("serialization must succeed");
         let restored: ChannelManifest = serde_json::from_str(&json).expect("deserialization must succeed");
 
@@ -503,45 +173,19 @@ mod tests {
     }
 
     #[test]
-    fn ur5_manifest_has_correct_channels() {
-        let m = ChannelManifest::ur5();
+    fn generic_velocity_has_correct_channels() {
+        let m = ChannelManifest::generic_velocity(6, PI);
 
-        assert_eq!(m.command_count(), 6, "UR5 must have 6 velocity command channels");
-        assert_eq!(
-            m.state_count(),
-            12,
-            "UR5 must have 12 state channels (6 position + 6 velocity)"
-        );
+        assert_eq!(m.command_count(), 6, "generic_velocity(6) must have 6 command channels");
+        assert_eq!(m.state_count(), 0, "generic_velocity has no state channels");
 
-        // Every command channel must be Velocity and reference its matching position state.
         for (i, cmd) in m.commands.iter().enumerate() {
             assert_eq!(
                 cmd.interface_type,
                 InterfaceType::Velocity,
                 "command {i} must be Velocity"
             );
-            assert_eq!(
-                cmd.position_state_index,
-                Some(i),
-                "command {i} must pair with position state index {i}"
-            );
-        }
-
-        // First 6 state channels are Position, next 6 are Velocity.
-        for (i, state) in m.states[..6].iter().enumerate() {
-            assert_eq!(
-                state.interface_type,
-                InterfaceType::Position,
-                "state {i} must be Position"
-            );
-        }
-        for (i, state) in m.states[6..].iter().enumerate() {
-            assert_eq!(
-                state.interface_type,
-                InterfaceType::Velocity,
-                "state {} must be Velocity",
-                i + 6
-            );
+            assert_eq!(cmd.limits, (-PI, PI), "command {i} must have symmetric PI limits");
         }
 
         assert_eq!(m.robot_class, "manipulator");
@@ -549,68 +193,17 @@ mod tests {
     }
 
     #[test]
-    fn quadcopter_manifest_has_4_commands() {
-        let m = ChannelManifest::quadcopter();
-
-        assert_eq!(
-            m.command_count(),
-            4,
-            "quadcopter must have 4 body velocity command channels"
-        );
-        assert_eq!(m.state_count(), 4);
-        assert_eq!(m.robot_class, "drone");
-
-        // All 4 command channels must be Velocity.
-        for (i, cmd) in m.commands.iter().enumerate() {
-            assert_eq!(
-                cmd.interface_type,
-                InterfaceType::Velocity,
-                "command {i} must be Velocity"
-            );
-        }
+    fn default_manifest_is_empty() {
+        let m = ChannelManifest::default();
+        assert_eq!(m.command_count(), 0);
+        assert_eq!(m.state_count(), 0);
+        assert_eq!(m.control_rate_hz, 100);
     }
 
     #[test]
-    fn diff_drive_manifest_has_2_commands() {
-        let m = ChannelManifest::diff_drive();
-
-        assert_eq!(m.command_count(), 2, "diff_drive must have 2 twist command channels");
-        assert_eq!(m.state_count(), 3);
-        assert_eq!(m.robot_class, "mobile");
-
-        assert_eq!(m.commands[0].name, "base/linear.x");
-        assert_eq!(m.commands[1].name, "base/angular.z");
-    }
-
-    #[test]
-    fn reachy_mini_manifest_structure() {
-        let m = ChannelManifest::reachy_mini();
-        assert_eq!(m.robot_id, "reachy_mini");
-        assert_eq!(m.robot_class, "expressive");
-        assert_eq!(m.control_rate_hz, 50);
-        assert_eq!(m.commands.len(), 9);
-        assert_eq!(m.states.len(), 9);
-
-        assert_eq!(m.commands[0].name, "head/position.x");
-        assert_eq!(m.commands[5].name, "head/orientation.yaw");
-        assert_eq!(m.commands[6].name, "body/yaw");
-        assert_eq!(m.commands[7].name, "left_antenna/position");
-        assert_eq!(m.commands[8].name, "right_antenna/position");
-
-        // All position type
-        assert!(m.commands.iter().all(|c| c.interface_type == InterfaceType::Position));
-
-        // Head pitch ±40 deg
-        let limit_40 = 40.0_f64.to_radians();
-        assert!((m.commands[4].limits.1 - limit_40).abs() < 0.001);
-
-        // Body yaw ±160 deg
-        let limit_160 = 160.0_f64.to_radians();
-        assert!((m.commands[6].limits.1 - limit_160).abs() < 0.001);
-
-        // State/command pairing
-        for (i, cmd) in m.commands.iter().enumerate() {
-            assert_eq!(cmd.position_state_index, Some(i));
-        }
+    fn position_state_count_filters_correctly() {
+        let m = ChannelManifest::generic_velocity(4, 1.0);
+        // generic_velocity has no state channels at all.
+        assert_eq!(m.position_state_count(), 0);
     }
 }

--- a/crates/roz-core/src/command.rs
+++ b/crates/roz-core/src/command.rs
@@ -169,6 +169,16 @@ impl CommandFrame {
     pub fn zero(n: usize) -> Self {
         Self { values: vec![0.0; n] }
     }
+
+    /// Create a frame with each channel set to its manifest default.
+    ///
+    /// Use this for safe-stop instead of `zero()` on position-controlled robots,
+    /// where zero means "go to mechanical origin" rather than "stop."
+    pub fn from_defaults(manifest: &crate::channels::ChannelManifest) -> Self {
+        Self {
+            values: manifest.commands.iter().map(|c| c.default).collect(),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -460,5 +470,54 @@ mod tests {
 
         let next3 = next2.transition(CommandEvent::ReportProgress).unwrap();
         assert_eq!(next3, CommandState::Progress);
+    }
+
+    #[test]
+    fn command_frame_from_defaults_uses_manifest() {
+        use crate::channels::{ChannelDescriptor, ChannelManifest, InterfaceType};
+
+        let manifest = ChannelManifest {
+            robot_id: "test".into(),
+            robot_class: "test".into(),
+            control_rate_hz: 50,
+            commands: vec![
+                ChannelDescriptor {
+                    name: "a".into(),
+                    interface_type: InterfaceType::Position,
+                    unit: "rad".into(),
+                    limits: (-1.0, 1.0),
+                    default: 0.5, // non-zero default
+                    max_rate_of_change: None,
+                    position_state_index: None,
+                },
+                ChannelDescriptor {
+                    name: "b".into(),
+                    interface_type: InterfaceType::Velocity,
+                    unit: "rad/s".into(),
+                    limits: (-1.5, 1.5),
+                    default: 0.0,
+                    max_rate_of_change: None,
+                    position_state_index: None,
+                },
+            ],
+            states: vec![],
+        };
+        let frame = CommandFrame::from_defaults(&manifest);
+        assert_eq!(frame.values.len(), 2);
+        assert!(
+            (frame.values[0] - 0.5).abs() < f64::EPSILON,
+            "should use channel default 0.5"
+        );
+        assert!(
+            (frame.values[1] - 0.0).abs() < f64::EPSILON,
+            "should use channel default 0.0"
+        );
+    }
+
+    #[test]
+    fn command_frame_from_defaults_empty_manifest() {
+        let manifest = crate::channels::ChannelManifest::default();
+        let frame = CommandFrame::from_defaults(&manifest);
+        assert!(frame.values.is_empty());
     }
 }

--- a/crates/roz-core/src/command.rs
+++ b/crates/roz-core/src/command.rs
@@ -489,6 +489,7 @@ mod tests {
                     default: 0.5, // non-zero default
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
                 ChannelDescriptor {
                     name: "b".into(),
@@ -498,6 +499,7 @@ mod tests {
                     default: 0.0,
                     max_rate_of_change: None,
                     position_state_index: None,
+                    max_delta_from: None,
                 },
             ],
             states: vec![],

--- a/crates/roz-local/src/runtime.rs
+++ b/crates/roz-local/src/runtime.rs
@@ -502,9 +502,7 @@ impl LocalRuntime {
             extensions.insert(handle.cmd_tx());
             // Load channel manifest from robot.toml if present in project directory.
             let robot_toml_path = self.project_dir.join("robot.toml");
-            if let Ok(robot_manifest) =
-                roz_copper::manifest::RobotManifest::load(&robot_toml_path)
-            {
+            if let Ok(robot_manifest) = roz_copper::manifest::RobotManifest::load(&robot_toml_path) {
                 if let Some(channel_manifest) = robot_manifest.channel_manifest() {
                     extensions.insert(channel_manifest);
                 }

--- a/crates/roz-local/src/runtime.rs
+++ b/crates/roz-local/src/runtime.rs
@@ -496,10 +496,12 @@ impl LocalRuntime {
             );
         }
 
-        // Build Extensions with cmd_tx if controller is running
+        // Build Extensions with cmd_tx + manifest if controller is running
         let mut extensions = roz_agent::dispatch::Extensions::new();
         if let Some(ref handle) = self.copper_handle {
             extensions.insert(handle.cmd_tx());
+            // TODO(reachy-mini): Read manifest from ProjectManifest / roz.toml.
+            extensions.insert(roz_core::channels::ChannelManifest::ur5());
         }
 
         // System prompt blocks

--- a/crates/roz-local/src/runtime.rs
+++ b/crates/roz-local/src/runtime.rs
@@ -500,8 +500,18 @@ impl LocalRuntime {
         let mut extensions = roz_agent::dispatch::Extensions::new();
         if let Some(ref handle) = self.copper_handle {
             extensions.insert(handle.cmd_tx());
-            // TODO(reachy-mini): Read manifest from ProjectManifest / roz.toml.
-            extensions.insert(roz_core::channels::ChannelManifest::ur5());
+            // Load channel manifest from robot.toml if present in project directory.
+            let robot_toml_path = self.project_dir.join("robot.toml");
+            if let Ok(robot_manifest) =
+                roz_copper::manifest::RobotManifest::load(&robot_toml_path)
+            {
+                if let Some(channel_manifest) = robot_manifest.channel_manifest() {
+                    extensions.insert(channel_manifest);
+                }
+            } else {
+                // No robot.toml — deploy_controller will error if called without a manifest.
+                tracing::debug!("no robot.toml found, skipping channel manifest injection");
+            }
         }
 
         // System prompt blocks

--- a/crates/roz-local/src/tools/deploy_controller.rs
+++ b/crates/roz-local/src/tools/deploy_controller.rs
@@ -148,7 +148,10 @@ mod tests {
         let (tx, rx) = mpsc::channel(16);
         let mut ext = Extensions::new();
         ext.insert(tx);
-        ext.insert(roz_core::channels::ChannelManifest::ur5());
+        ext.insert(roz_core::channels::ChannelManifest::generic_velocity(
+            6,
+            std::f64::consts::PI,
+        ));
         let ctx = ToolContext {
             task_id: "test".into(),
             tenant_id: "test".into(),

--- a/crates/roz-local/src/tools/deploy_controller.rs
+++ b/crates/roz-local/src/tools/deploy_controller.rs
@@ -56,9 +56,21 @@ impl TypedToolExecutor for DeployControllerTool {
         input: Self::Input,
         ctx: &ToolContext,
     ) -> Result<ToolResult, Box<dyn std::error::Error + Send + Sync>> {
+        // 0. Read manifest from extensions — no UR5 fallback.
+        let manifest = ctx
+            .extensions
+            .get::<roz_core::channels::ChannelManifest>()
+            .cloned()
+            .ok_or_else(|| {
+                Box::<dyn std::error::Error + Send + Sync>::from(
+                    "no ChannelManifest in ToolContext — configure the robot type before deploying controllers",
+                )
+            })?;
+
         // 1. Compile and verify — CPU-bound; run on blocking thread pool.
         let code_bytes = input.code.as_bytes().to_vec();
-        let outcome = tokio::task::spawn_blocking(move || verify_wasm(&code_bytes))
+        let verify_manifest = manifest.clone();
+        let outcome = tokio::task::spawn_blocking(move || verify_wasm(&code_bytes, &verify_manifest))
             .await
             .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
                 Box::new(std::io::Error::other(format!("verification task panicked: {e}")))
@@ -77,7 +89,6 @@ impl TypedToolExecutor for DeployControllerTool {
         })?;
 
         // 3. Deploy
-        let manifest = roz_core::channels::ChannelManifest::ur5();
         cmd_tx
             .send(ControllerCommand::LoadWasm(input.code.into_bytes(), manifest))
             .await
@@ -101,9 +112,8 @@ impl TypedToolExecutor for DeployControllerTool {
 /// compilation or tick failure.
 ///
 /// Designed to run inside `spawn_blocking` because wasmtime is CPU-bound.
-fn verify_wasm(code: &[u8]) -> VerifyOutcome {
-    let manifest = roz_core::channels::ChannelManifest::ur5();
-    let host_ctx = roz_copper::wit_host::HostContext::with_manifest(manifest);
+fn verify_wasm(code: &[u8], manifest: &roz_core::channels::ChannelManifest) -> VerifyOutcome {
+    let host_ctx = roz_copper::wit_host::HostContext::with_manifest(manifest.clone());
 
     let mut task = match roz_copper::wasm::CuWasmTask::from_source_with_host(code, host_ctx) {
         Ok(t) => t,
@@ -138,6 +148,7 @@ mod tests {
         let (tx, rx) = mpsc::channel(16);
         let mut ext = Extensions::new();
         ext.insert(tx);
+        ext.insert(roz_core::channels::ChannelManifest::ur5());
         let ctx = ToolContext {
             task_id: "test".into(),
             tenant_id: "test".into(),

--- a/crates/roz-local/tests/live_claude_wasm.rs
+++ b/crates/roz-local/tests/live_claude_wasm.rs
@@ -17,7 +17,10 @@ async fn real_claude_writes_wat_and_deploys_controller() {
     // 2. Build Extensions with cmd_tx + manifest
     let mut extensions = roz_agent::dispatch::Extensions::new();
     extensions.insert(handle.cmd_tx());
-    extensions.insert(roz_core::channels::ChannelManifest::ur5());
+    extensions.insert(roz_core::channels::ChannelManifest::generic_velocity(
+        6,
+        std::f64::consts::PI,
+    ));
 
     // 3. Create real Claude model
     let model = roz_agent::model::create_model("claude-sonnet-4-6", "", "", 120, "anthropic", Some(&api_key)).unwrap();
@@ -30,7 +33,7 @@ async fn real_claude_writes_wat_and_deploys_controller() {
     );
 
     // 5. Robot context in system prompt
-    let manifest = roz_core::channels::ChannelManifest::ur5();
+    let manifest = roz_core::channels::ChannelManifest::generic_velocity(6, std::f64::consts::PI);
     let robot_context = format!(
         "You are a robot controller engineer. You write WAT code for WASM controllers.\n\n\
          Available WASM host functions:\n\

--- a/crates/roz-local/tests/live_claude_wasm.rs
+++ b/crates/roz-local/tests/live_claude_wasm.rs
@@ -14,9 +14,10 @@ async fn real_claude_writes_wat_and_deploys_controller() {
         None,
     );
 
-    // 2. Build Extensions with cmd_tx
+    // 2. Build Extensions with cmd_tx + manifest
     let mut extensions = roz_agent::dispatch::Extensions::new();
     extensions.insert(handle.cmd_tx());
+    extensions.insert(roz_core::channels::ChannelManifest::ur5());
 
     // 3. Create real Claude model
     let model = roz_agent::model::create_model("claude-sonnet-4-6", "", "", 120, "anthropic", Some(&api_key)).unwrap();

--- a/crates/roz-local/tests/live_claude_wasm_gazebo.rs
+++ b/crates/roz-local/tests/live_claude_wasm_gazebo.rs
@@ -132,6 +132,7 @@ async fn full_vertical_claude_wasm_gazebo() {
     // 4. Agent setup
     let mut extensions = Extensions::new();
     extensions.insert(handle.cmd_tx());
+    extensions.insert(manifest.clone());
     let dispatcher = build_dispatcher(&mcp);
     let model = roz_agent::model::create_model("claude-sonnet-4-6", "", "", 120, "anthropic", Some(&api_key)).unwrap();
     let safety = SafetyStack::new(vec![]);

--- a/crates/roz-local/tests/live_claude_wasm_gazebo.rs
+++ b/crates/roz-local/tests/live_claude_wasm_gazebo.rs
@@ -14,7 +14,6 @@ use roz_copper::handle::CopperHandle;
 use roz_copper::io::ActuatorSink;
 use roz_copper::io_grpc::{GrpcActuatorSink, GrpcSensorSource};
 use roz_copper::io_log::TeeActuatorSink;
-use roz_core::channels::ChannelManifest;
 use roz_local::mcp::{McpManager, McpToolExecutor};
 
 const BRIDGE_CONTROL_URL: &str = "http://127.0.0.1:9094";
@@ -109,7 +108,11 @@ async fn full_vertical_claude_wasm_gazebo() {
         .connect()
         .await
         .expect("gRPC channel to bridge should connect");
-    let manifest = ChannelManifest::ur5();
+    let manifest = {
+        let toml_str = include_str!("../../../examples/ur5/robot.toml");
+        let robot: roz_copper::manifest::RobotManifest = toml::from_str(toml_str).unwrap();
+        robot.channel_manifest().unwrap()
+    };
     let grpc_sink = Arc::new(GrpcActuatorSink::from_manifest(
         channel,
         &manifest,

--- a/crates/roz-worker/src/dispatch.rs
+++ b/crates/roz-worker/src/dispatch.rs
@@ -40,8 +40,9 @@ pub fn build_agent_input(inv: &TaskInvocation) -> AgentInput {
     };
 
     // Inject robot controller interface context.
-    // For now, always inject UR5 manifest. In production, fetch from bridge.
-    let manifest = roz_core::channels::ChannelManifest::ur5();
+    // TODO(reachy-mini): Read manifest from EnvironmentConfig in task invocation.
+    // Empty manifest means no channel documentation in system prompt.
+    let manifest = roz_core::channels::ChannelManifest::default();
     let robot_context = format!(
         "## Robot Controller Interface\n\
          Robot: {} ({})\n\
@@ -295,9 +296,10 @@ mod tests {
             input.system_prompt[1].contains("## Robot Controller Interface"),
             "second block should be robot context"
         );
+        // Default manifest has empty robot_id (no hardcoded UR5).
         assert!(
-            input.system_prompt[1].contains("ur5"),
-            "robot context should reference ur5"
+            !input.system_prompt[1].contains("ur5"),
+            "robot context should NOT hardcode ur5"
         );
         assert_eq!(input.max_cycles, DEFAULT_MAX_CYCLES);
         assert_eq!(input.max_tokens, DEFAULT_MAX_TOKENS);

--- a/crates/roz-worker/src/main.rs
+++ b/crates/roz-worker/src/main.rs
@@ -78,6 +78,8 @@ async fn execute_task(
     let mut extensions = roz_agent::dispatch::Extensions::new();
     if let Some(ref handle) = copper_handle {
         extensions.insert(handle.cmd_tx());
+        // TODO(reachy-mini): Read manifest from EnvironmentConfig in task invocation.
+        extensions.insert(roz_core::channels::ChannelManifest::ur5());
         dispatcher.register_with_category(
             Box::new(roz_local::tools::deploy_controller::DeployControllerTool),
             roz_core::tools::ToolCategory::Physical,

--- a/crates/roz-worker/src/main.rs
+++ b/crates/roz-worker/src/main.rs
@@ -78,8 +78,8 @@ async fn execute_task(
     let mut extensions = roz_agent::dispatch::Extensions::new();
     if let Some(ref handle) = copper_handle {
         extensions.insert(handle.cmd_tx());
-        // TODO(reachy-mini): Read manifest from EnvironmentConfig in task invocation.
-        extensions.insert(roz_core::channels::ChannelManifest::ur5());
+        // TODO: Load ChannelManifest from EnvironmentConfig in task invocation.
+        extensions.insert(roz_core::channels::ChannelManifest::default());
         dispatcher.register_with_category(
             Box::new(roz_local::tools::deploy_controller::DeployControllerTool),
             roz_core::tools::ToolCategory::Physical,

--- a/crates/roz-worker/src/spatial_bridge.rs
+++ b/crates/roz-worker/src/spatial_bridge.rs
@@ -40,6 +40,9 @@ impl SpatialContextProvider for CopperSpatialProvider {
         if let Some(ref output) = current.last_output {
             properties.insert("last_output".to_string(), output.clone());
         }
+        if let Some(ref reason) = current.estop_reason {
+            properties.insert("estop_reason".to_string(), serde_json::Value::from(reason.as_str()));
+        }
 
         let controller_entity = EntityState {
             id: "copper_controller".to_string(),
@@ -76,6 +79,7 @@ mod tests {
             running: true,
             last_output: Some(serde_json::json!({"velocity": [0.1, -0.2]})),
             entities: vec![],
+            estop_reason: None,
         }));
 
         let provider = CopperSpatialProvider::new(Arc::clone(&state));
@@ -120,6 +124,7 @@ mod tests {
             running: true,
             last_output: None,
             entities: vec![arm_entity],
+            estop_reason: None,
         }));
 
         let provider = CopperSpatialProvider::new(state);

--- a/examples/diff_drive/robot.toml
+++ b/examples/diff_drive/robot.toml
@@ -1,0 +1,49 @@
+[robot]
+name = "diff_drive"
+description = "Differential-drive mobile robot — 2-DOF twist commands"
+
+[safety]
+e_stop_behavior = "hold_position"
+watchdog_timeout_ms = 500
+
+[channels]
+robot_id = "diff_drive"
+robot_class = "mobile"
+control_rate_hz = 100
+
+# 2 twist command channels.
+# PI = 3.141592653589793
+
+[[channels.commands]]
+name = "base/linear.x"
+type = "velocity"
+unit = "m/s"
+limits = [-1.0, 1.0]
+max_rate_of_change = 0.5
+
+[[channels.commands]]
+name = "base/angular.z"
+type = "velocity"
+unit = "rad/s"
+limits = [-2.0, 2.0]
+max_rate_of_change = 1.0
+
+# 3 odometry state channels.
+
+[[channels.states]]
+name = "base/odom.x"
+type = "position"
+unit = "m"
+limits = [-1000.0, 1000.0]
+
+[[channels.states]]
+name = "base/odom.y"
+type = "position"
+unit = "m"
+limits = [-1000.0, 1000.0]
+
+[[channels.states]]
+name = "base/odom.yaw"
+type = "position"
+unit = "rad"
+limits = [-3.141592653589793, 3.141592653589793]

--- a/examples/quadcopter/robot.toml
+++ b/examples/quadcopter/robot.toml
@@ -1,0 +1,70 @@
+[robot]
+name = "quadcopter"
+description = "Generic quadcopter — 4-DOF body velocity control"
+
+[safety]
+e_stop_behavior = "hold_position"
+watchdog_timeout_ms = 500
+
+[channels]
+robot_id = "quadcopter"
+robot_class = "drone"
+control_rate_hz = 100
+
+# 4 body velocity command channels.
+# FRAC_PI_2 = 1.5707963267948966
+
+[[channels.commands]]
+name = "body/velocity.x"
+type = "velocity"
+unit = "m/s"
+limits = [-5.0, 5.0]
+max_rate_of_change = 2.0
+
+[[channels.commands]]
+name = "body/velocity.y"
+type = "velocity"
+unit = "m/s"
+limits = [-5.0, 5.0]
+max_rate_of_change = 2.0
+
+[[channels.commands]]
+name = "body/velocity.z"
+type = "velocity"
+unit = "m/s"
+limits = [-3.0, 3.0]
+max_rate_of_change = 1.5
+
+[[channels.commands]]
+name = "body/yaw_rate"
+type = "velocity"
+unit = "rad/s"
+limits = [-1.5707963267948966, 1.5707963267948966]
+max_rate_of_change = 1.0
+
+# 4 body position state channels.
+# PI = 3.141592653589793
+
+[[channels.states]]
+name = "body/position.x"
+type = "position"
+unit = "m"
+limits = [-1000.0, 1000.0]
+
+[[channels.states]]
+name = "body/position.y"
+type = "position"
+unit = "m"
+limits = [-1000.0, 1000.0]
+
+[[channels.states]]
+name = "body/position.z"
+type = "position"
+unit = "m"
+limits = [0.0, 500.0]
+
+[[channels.states]]
+name = "body/yaw"
+type = "position"
+unit = "rad"
+limits = [-3.141592653589793, 3.141592653589793]

--- a/examples/reachy-mini/robot.toml
+++ b/examples/reachy-mini/robot.toml
@@ -1,0 +1,142 @@
+[robot]
+name = "reachy-mini"
+description = "Pollen Robotics Reachy Mini — expressive tabletop robot with head, body, and antennas"
+
+[safety]
+e_stop_behavior = "hold_position"
+watchdog_timeout_ms = 500
+
+[channels]
+robot_id = "reachy_mini"
+robot_class = "expressive"
+control_rate_hz = 50
+
+# 9 position command channels.
+# 40 deg = 0.6981317007977318
+# 160 deg = 2.792526803190927
+# 65 deg = 1.1344640137963142
+# 120 deg = 2.0943951023931953
+
+# Head position (indices 0-2)
+[[channels.commands]]
+name = "head/position.x"
+type = "position"
+unit = "m"
+limits = [-0.03, 0.03]
+position_state_index = 0
+
+[[channels.commands]]
+name = "head/position.y"
+type = "position"
+unit = "m"
+limits = [-0.03, 0.03]
+position_state_index = 1
+
+[[channels.commands]]
+name = "head/position.z"
+type = "position"
+unit = "m"
+limits = [-0.015, 0.015]
+position_state_index = 2
+
+# Head orientation (indices 3-5)
+[[channels.commands]]
+name = "head/orientation.roll"
+type = "position"
+unit = "rad"
+limits = [-0.6981317007977318, 0.6981317007977318]
+position_state_index = 3
+
+[[channels.commands]]
+name = "head/orientation.pitch"
+type = "position"
+unit = "rad"
+limits = [-0.6981317007977318, 0.6981317007977318]
+position_state_index = 4
+
+[[channels.commands]]
+name = "head/orientation.yaw"
+type = "position"
+unit = "rad"
+limits = [-3.141592653589793, 3.141592653589793]
+position_state_index = 5
+max_delta_from = [6, 1.1344640137963142]
+
+# Body yaw (index 6)
+[[channels.commands]]
+name = "body/yaw"
+type = "position"
+unit = "rad"
+limits = [-2.792526803190927, 2.792526803190927]
+position_state_index = 6
+
+# Antennas (indices 7-8)
+[[channels.commands]]
+name = "left_antenna/position"
+type = "position"
+unit = "rad"
+limits = [0.0, 2.0943951023931953]
+position_state_index = 7
+
+[[channels.commands]]
+name = "right_antenna/position"
+type = "position"
+unit = "rad"
+limits = [0.0, 2.0943951023931953]
+position_state_index = 8
+
+# 9 state channels — mirror commands.
+
+[[channels.states]]
+name = "head/position.x"
+type = "position"
+unit = "m"
+limits = [-0.03, 0.03]
+
+[[channels.states]]
+name = "head/position.y"
+type = "position"
+unit = "m"
+limits = [-0.03, 0.03]
+
+[[channels.states]]
+name = "head/position.z"
+type = "position"
+unit = "m"
+limits = [-0.015, 0.015]
+
+[[channels.states]]
+name = "head/orientation.roll"
+type = "position"
+unit = "rad"
+limits = [-0.6981317007977318, 0.6981317007977318]
+
+[[channels.states]]
+name = "head/orientation.pitch"
+type = "position"
+unit = "rad"
+limits = [-0.6981317007977318, 0.6981317007977318]
+
+[[channels.states]]
+name = "head/orientation.yaw"
+type = "position"
+unit = "rad"
+limits = [-3.141592653589793, 3.141592653589793]
+
+[[channels.states]]
+name = "body/yaw"
+type = "position"
+unit = "rad"
+limits = [-2.792526803190927, 2.792526803190927]
+
+[[channels.states]]
+name = "left_antenna/position"
+type = "position"
+unit = "rad"
+limits = [0.0, 2.0943951023931953]
+
+[[channels.states]]
+name = "right_antenna/position"
+type = "position"
+unit = "rad"
+limits = [0.0, 2.0943951023931953]

--- a/examples/ur5/robot.toml
+++ b/examples/ur5/robot.toml
@@ -1,0 +1,140 @@
+[robot]
+name = "ur5"
+description = "Universal Robots UR5 — 6-DOF industrial manipulator arm"
+
+[safety]
+e_stop_behavior = "hold_position"
+watchdog_timeout_ms = 500
+max_contact_force_n = 150.0
+
+[channels]
+robot_id = "ur5"
+robot_class = "manipulator"
+control_rate_hz = 100
+
+# 6 velocity command channels — one per joint.
+# PI = 3.141592653589793
+# max_rate_of_change = 0.5 (50 rad/s^2 at 100 Hz)
+
+[[channels.commands]]
+name = "shoulder_pan_joint/velocity"
+type = "velocity"
+unit = "rad/s"
+limits = [-3.141592653589793, 3.141592653589793]
+max_rate_of_change = 0.5
+position_state_index = 0
+
+[[channels.commands]]
+name = "shoulder_lift_joint/velocity"
+type = "velocity"
+unit = "rad/s"
+limits = [-3.141592653589793, 3.141592653589793]
+max_rate_of_change = 0.5
+position_state_index = 1
+
+[[channels.commands]]
+name = "elbow_joint/velocity"
+type = "velocity"
+unit = "rad/s"
+limits = [-3.141592653589793, 3.141592653589793]
+max_rate_of_change = 0.5
+position_state_index = 2
+
+[[channels.commands]]
+name = "wrist_1_joint/velocity"
+type = "velocity"
+unit = "rad/s"
+limits = [-3.141592653589793, 3.141592653589793]
+max_rate_of_change = 0.5
+position_state_index = 3
+
+[[channels.commands]]
+name = "wrist_2_joint/velocity"
+type = "velocity"
+unit = "rad/s"
+limits = [-3.141592653589793, 3.141592653589793]
+max_rate_of_change = 0.5
+position_state_index = 4
+
+[[channels.commands]]
+name = "wrist_3_joint/velocity"
+type = "velocity"
+unit = "rad/s"
+limits = [-3.141592653589793, 3.141592653589793]
+max_rate_of_change = 0.5
+position_state_index = 5
+
+# 12 state channels: 6 position (indices 0-5) + 6 velocity (indices 6-11).
+# TAU = 6.283185307179586
+
+[[channels.states]]
+name = "shoulder_pan_joint/position"
+type = "position"
+unit = "rad"
+limits = [-6.283185307179586, 6.283185307179586]
+
+[[channels.states]]
+name = "shoulder_lift_joint/position"
+type = "position"
+unit = "rad"
+limits = [-6.283185307179586, 6.283185307179586]
+
+[[channels.states]]
+name = "elbow_joint/position"
+type = "position"
+unit = "rad"
+limits = [-6.283185307179586, 6.283185307179586]
+
+[[channels.states]]
+name = "wrist_1_joint/position"
+type = "position"
+unit = "rad"
+limits = [-6.283185307179586, 6.283185307179586]
+
+[[channels.states]]
+name = "wrist_2_joint/position"
+type = "position"
+unit = "rad"
+limits = [-6.283185307179586, 6.283185307179586]
+
+[[channels.states]]
+name = "wrist_3_joint/position"
+type = "position"
+unit = "rad"
+limits = [-6.283185307179586, 6.283185307179586]
+
+[[channels.states]]
+name = "shoulder_pan_joint/velocity"
+type = "velocity"
+unit = "rad/s"
+limits = [-3.141592653589793, 3.141592653589793]
+
+[[channels.states]]
+name = "shoulder_lift_joint/velocity"
+type = "velocity"
+unit = "rad/s"
+limits = [-3.141592653589793, 3.141592653589793]
+
+[[channels.states]]
+name = "elbow_joint/velocity"
+type = "velocity"
+unit = "rad/s"
+limits = [-3.141592653589793, 3.141592653589793]
+
+[[channels.states]]
+name = "wrist_1_joint/velocity"
+type = "velocity"
+unit = "rad/s"
+limits = [-3.141592653589793, 3.141592653589793]
+
+[[channels.states]]
+name = "wrist_2_joint/velocity"
+type = "velocity"
+unit = "rad/s"
+limits = [-3.141592653589793, 3.141592653589793]
+
+[[channels.states]]
+name = "wrist_3_joint/velocity"
+type = "velocity"
+unit = "rad/s"
+limits = [-3.141592653589793, 3.141592653589793]


### PR DESCRIPTION
## Summary

Infrastructure to support position-controlled robots and load robot config from `robot.toml` instead of compiled-in code. Zero robot-specific code in roz-core.

### Safety fixes
- **Position-aware clamping** -- position channels clamp to boundary, not zero (zero = go-to-origin)
- **CommandFrame::from_defaults()** -- safe-stop sends per-channel defaults
- **Configurable tick rate** -- controller loop reads `control_rate_hz` from manifest
- **E-stop propagation** -- controller loop notifies supervisor via dedicated channel

### Infrastructure
- **Cross-channel delta constraint** -- `max_delta_from` on ChannelDescriptor for coupled limits
- **UpdateParams + config host functions** -- agent tunes WASM controller params at runtime
- **StateInjector trait** -- generic sensor injection into WASM HostContext
- **Manifest-agnostic tools** -- deploy_controller/execute_code read manifest from context
- **robot.toml wiring** -- RobotManifest gains `[channels]` section; LocalRuntime loads it

### Robot descriptions are data, not code
Removed `ur5()`, `quadcopter()`, `diff_drive()`, `reachy_mini()` factory methods from roz-core. Following ROS2/Drake/MuJoCo pattern: framework defines the grammar, data provides instances. Robot configs now live in `examples/{robot}/robot.toml`. Tests use `generic_velocity()` or TOML fixtures.

## Test plan
- [x] 1,552 workspace tests pass (Postgres + NATS + JetStream)
- [x] Position-aware clamping verified with dedicated tests
- [x] E-stop propagation verified end-to-end
- [x] Cross-channel delta constraint tested
- [x] robot.toml round-trip verification for all 4 robots
- [x] Zero clippy warnings

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Robot configuration now loaded from TOML files with support for command/state channels, control rates, and cross-channel constraints
  * E-stop system now tracks and communicates stop reasons via dedicated channels
  * WASM controllers can receive injected configuration and per-tick state updates
  * Support for dynamic control rate configuration from robot manifest

<!-- end of auto-generated comment: release notes by coderabbit.ai -->